### PR TITLE
Fix for nightly builds due to PARAMS.ENVIROMENT not existing

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -14,7 +14,7 @@ def product = "idam"
 def component = "user-dashboard"
 
 def secrets = [
-  'idam-idam-${params.ENVIRONMENT}': [
+  'idam-idam-${env}': [
     secret('smoke-test-user-username', 'SMOKE_TEST_USER_USERNAME'),
     secret('smoke-test-user-password', 'SMOKE_TEST_USER_PASSWORD')
   ]


### PR DESCRIPTION
### Change description ###

- Updated to use other style of accessing env variable.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
