### PR TITLE
CVE-2022-0155 patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,5 +124,8 @@
     "webpack-cli": "^3.3.11",
     "webpack-dev-middleware": "^5.2.2",
     "webpack-node-externals": "^3.0.0"
+  },
+  "resolutions": {
+    "axios/follow-redirects": "^1.14.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5448,10 +5448,10 @@ fn-args@^4.0.0:
   resolved "https://registry.npmjs.org/fn-args/-/fn-args-4.0.0.tgz"
   integrity sha512-M9XSagc92ejQhi+7kjpFPAO59xKbGRsbOg/9dfwSj84DfzB0pj+Q81DVD1pKr084Xf2oICwUNI0pCvGORmD9zg==
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.4:
-  version "1.14.5"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz"
-  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Change description ###

- Upgradde follow-redirects to higher version to patch CVE-2022-0155 exploit

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
