### PR TITLE
Add IDAM_SYSTEM_OWNER to default role for sorting in the user results screen

### DIFF
--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -11,10 +11,16 @@ export const isValidEmailFormat = (email: string): boolean => {
   return filter.test(email);
 };
 
+const isDefaultRole = (role: string): boolean => {
+  return role === 'IDAM_SUPER_USER'
+    || role === 'IDAM_ADMIN_USER'
+    || role === 'IDAM_SYSTEM_OWNER';
+};
+
 const compareRoles = (a: string, b: string): number => {
-  if (a === 'IDAM_SUPER_USER' || a === 'IDAM_ADMIN_USER') {
+  if (isDefaultRole(a)) {
     return -1;
-  } else if (b === 'IDAM_SUPER_USER' || b === 'IDAM_ADMIN_USER') {
+  } else if (isDefaultRole(b)) {
     return 1;
   } else if (a < b) {
     return -1;

--- a/src/test/unit/test/utils/utils.ts
+++ b/src/test/unit/test/utils/utils.ts
@@ -66,6 +66,12 @@ describe('utils', () => {
       expect(roles[0]).toBe('IDAM_ADMIN_USER');
     });
 
+    test('Should sort IDAM system owner role first', async () => {
+      const roles = ['Other User', 'Other User 2', 'IDAM_SYSTEM_OWNER'];
+      sortRoles(roles);
+      expect(roles[0]).toBe('IDAM_SYSTEM_OWNER');
+    });
+
     test('Should sort all other roles alphabetically', async () => {
       const roles = ['C', 'A', 'IDAM_SUPER_USER', 'B'];
       sortRoles(roles);


### PR DESCRIPTION
### Change description ###

Add IDAM_SYSTEM_OWNER to default role for sorting in the user results screen

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
