### PR TITLE
SIDM-6753 - Added TEST_URL variable to nightly build

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -3,7 +3,8 @@
 properties([
   pipelineTriggers([cron('H 02 * * *')]),
   parameters([
-    string(name: 'ENVIRONMENT', defaultValue: 'aat', description: 'Environment to test')
+    string(name: 'ENVIRONMENT', defaultValue: 'aat', description: 'Environment to test'),
+    string(name: 'TEST_URL', defaultValue: 'https://idam-user-dashboard.aat.platform.hmcts.net', description: 'The URL you want to run tests against')
   ])
 ])
 


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/SIDM-6753

### Change description ###

- Added TEST_URL environment variable which should point to AAT url on nightly builds

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
