### PR TITLE
Switch from a GET to a POST for user-results due to security

### DIFF
--- a/src/main/controllers/UserResultsController.ts
+++ b/src/main/controllers/UserResultsController.ts
@@ -5,8 +5,8 @@ import { convertISODateTimeToUTCFormat, isEmpty, sortRoles } from '../utils/util
 import { validateEmail } from '../utils/validation';
 
 export class UserResultsController {
-  public async get(req: AuthedRequest, res: Response): Promise<void> {
-    const email  = req.query.email ? req.query.email as string : '';
+  public async post(req: AuthedRequest, res: Response): Promise<void> {
+    const email  = req.body.email ? req.body.email as string : '';
     const errorMessage = validateEmail(email);
 
     if (!isEmpty(errorMessage)) {

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -6,5 +6,5 @@ export default function(app: Application): void {
   app.post(HOME_URL, app.locals.container.cradle.userOptionController.post);
   app.get(ADD_USERS_URL, app.locals.container.cradle.addUsersController.get);
   app.get(MANAGER_USERS_URL, app.locals.container.cradle.manageUsersController.get);
-  app.get(USER_RESULTS_URL, app.locals.container.cradle.userResultsController.get);
+  app.post(USER_RESULTS_URL, app.locals.container.cradle.userResultsController.post);
 }

--- a/src/main/views/manage-users.njk
+++ b/src/main/views/manage-users.njk
@@ -24,7 +24,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Manage Users</h1>
-      <form method="GET" action="/user-results">
+      <form method="POST" action="/user-results">
         {{ csrfProtection() }}
         {{ govukInput({
           label: {

--- a/src/test/unit/test/controllers/UserResultsController.ts
+++ b/src/test/unit/test/controllers/UserResultsController.ts
@@ -34,18 +34,18 @@ describe('User results controller', () => {
     ];
     when(mockApi.getUsersByEmail as jest.Mock).calledWith(email).mockReturnValue(results);
 
-    req.query.email = email;
+    req.body.email = email;
     req.scope.cradle.api = mockApi;
-    await controller.get(req, res);
+    await controller.post(req, res);
     expect(res.render).toBeCalledWith('user-details', results[0]);
   });
 
   test('Should render the manage users page when searching with a non-existent email', async () => {
     when(mockApi.getUsersByEmail as jest.Mock).calledWith(email).mockReturnValue([]);
 
-    req.query.email = email;
+    req.body.email = email;
     req.scope.cradle.api = mockApi;
-    await controller.get(req, res);
+    await controller.post(req, res);
     expect(res.render).toBeCalledWith('manage-users', { search: email, result: [] });
   });
 
@@ -68,15 +68,15 @@ describe('User results controller', () => {
     ];
     when(mockApi.getUsersByEmail as jest.Mock).calledWith(email).mockReturnValue(results);
 
-    req.query.email = email;
+    req.body.email = email;
     req.scope.cradle.api = mockApi;
-    await controller.get(req, res);
+    await controller.post(req, res);
     expect(res.render).toBeCalledWith('manage-users', { search: email, result: results });
   });
 
   test('Should render the manage users page with error when searching with empty email', async () => {
-    req.query.email = '';
-    await controller.get(req, res);
+    req.body.email = '';
+    await controller.post(req, res);
     const expectedPageData: PageData = {
       hasError: true,
       errorMessage: MISSING_EMAIL_ERROR
@@ -85,8 +85,8 @@ describe('User results controller', () => {
   });
 
   test('Should render the manage users page with error when searching with email with invalid format', async () => {
-    req.query.email = 'any text';
-    await controller.get(req, res);
+    req.body.email = 'any text';
+    await controller.post(req, res);
     const expectedPageData: PageData = {
       hasError: true,
       errorMessage: INVALID_EMAIL_FORMAT_ERROR


### PR DESCRIPTION
### Change description ###

- Suggestion from @kremi on potentonal security issue where user email is exposed in UserResultsController requests.
- Switched to sending email data in POST rather than GET

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
