### PR TITLE
preview-redis - use idam-preview redis values in preview env

### DIFF
--- a/charts/idam-user-dashboard/Chart.yaml
+++ b/charts/idam-user-dashboard/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for idam-user-dashboard App
 name: idam-user-dashboard
 home: https://github.com/hmcts/idam-user-dashboard
-version: 0.0.7
+version: 0.0.8
 dependencies:
   - name: nodejs
     version: 2.3.8

--- a/charts/idam-user-dashboard/values.preview.template.yaml
+++ b/charts/idam-user-dashboard/values.preview.template.yaml
@@ -4,9 +4,13 @@ nodejs:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
   keyVaults:
-    "idam-idam":
-      resourceGroup: idam-idam
-      excludeEnvironmentSuffix: false
+    idam-idam-preview:
+      excludeEnvironmentSuffix: true
+      secrets:
+        - redis-hostname
+        - redis-port
+        - redis-key
+    idam-idam:
       secrets:
         - AppInsightsInstrumentationKey
         - launchdarkly-sdk-key

--- a/charts/idam-user-dashboard/values.yaml
+++ b/charts/idam-user-dashboard/values.yaml
@@ -8,9 +8,7 @@ nodejs:
   ingressHost: idam-user-dashboard.{{ .Values.global.environment }}.platform.hmcts.net
   image: 'hmctspublic.azurecr.io/idam/user-dashboard:latest'
   keyVaults:
-    "idam-idam":
-      resourceGroup: idam-idam
-      excludeEnvironmentSuffix: false
+    idam-idam:
       secrets:
         - AppInsightsInstrumentationKey
         - launchdarkly-sdk-key
@@ -26,11 +24,6 @@ nodejs:
     enabled: true
     maxReplicas: 4
     targetCPUUtilizationPercentage: 80
-
-global:
-  tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-  environment: preview
-  enableKeyVaults: true
 
 idam-pr:
   enabled: false

--- a/src/main/modules/properties-volume/index.ts
+++ b/src/main/modules/properties-volume/index.ts
@@ -15,7 +15,16 @@ export class PropertiesVolume {
       this.setSecret('secrets.idam-idam.redis-hostname', 'session.redis.host');
       this.setSecret('secrets.idam-idam.redis-port', 'session.redis.port');
       this.setSecret('secrets.idam-idam.redis-key', 'session.redis.key');
-      this.setSecret('secrets.idam-idam.redis-key', 'session.secret');
+
+      // Use idam-preview redis if using idam-idam-preview kv
+      if(config.has('secrets.idam-idam-preview')) {
+        console.log('Using idam-preview redis');
+        this.setSecret('secrets.idam-idam-preview.redis-hostname', 'session.redis.host');
+        this.setSecret('secrets.idam-idam-preview.redis-port', 'session.redis.port');
+        this.setSecret('secrets.idam-idam-preview.redis-key', 'session.redis.key');
+      }
+
+      this.setSecret('session.redis.key', 'session.secret');
     } else {
       this.setLocalSecret('AppInsightsInstrumentationKey', 'appInsights.instrumentationKey');
       this.setLocalSecret('launchdarkly-sdk-key', 'featureFlags.launchdarkly.sdkKey');


### PR DESCRIPTION
### Change description ###

- Hardcode idam-idam-preview kv into preview charts
- Override AAT redis values with preview values if idam-idam-preview kv is used

I think this is kinda hacky but I was unable to get anything else working consistently. A better solution would be to add preview redis values into kv and then use an alias to override them in the charts like

```
  keyVaults:
    idam-idam:
      secrets:
        - AppInsightsInstrumentationKey
        - launchdarkly-sdk-key
        - idam-user-dashboard-client-secret
        - name: redis-hostname-preview
          alias: redis-hostname
        - name: redis-port-preview
          alias: redis-port-preview
        - redis-key-preview
          alias: redis-key-preview
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
