### PR TITLE
Fix Safari on local env / Helmet to not use defaults option

### DIFF
--- a/src/main/modules/helmet/index.ts
+++ b/src/main/modules/helmet/index.ts
@@ -25,6 +25,7 @@ export class Helmet {
   private setContentSecurityPolicy(app: express.Express): void {
     app.use(
       helmet.contentSecurityPolicy({
+        useDefaults: false,
         directives: {
           connectSrc: [self],
           defaultSrc: ["'none'"],


### PR DESCRIPTION
### Change description ###

- Sets useDefaults back to false, just like in helmet 4.6.0, fixes issue where assets/links are served incorrectly on local instance, especially when running cross-browser tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
