### PR TITLE
async-error-wrap - Added asyncError class/method decorator

### DIFF
--- a/src/main/controllers/RootController.ts
+++ b/src/main/controllers/RootController.ts
@@ -1,10 +1,11 @@
 import { AuthedRequest } from '../interfaces/AuthedRequest';
-import { Response } from 'express';
+import { NextFunction, Response } from 'express';
 import { PageData } from '../interfaces/PageData';
 import { FeatureFlags } from '../app/feature-flags/FeatureFlags';
 import autobind from 'autobind-decorator';
 import { isObjectEmpty } from '../utils/utils';
 import * as urls from '../utils/urls';
+import asyncError from '../modules/error-handler/asyncErrorDecorator';
 
 @autobind
 export class RootController {
@@ -13,14 +14,15 @@ export class RootController {
   }
 
   public get(req: AuthedRequest, res: Response, view: string, data?: PageData): Promise<void> | void {
-    return this.render(req, res, view, data);
+    return this.render(req, res, req.next, view, data);
   }
 
   public post(req: AuthedRequest, res: Response, view: string, data?: PageData): Promise<void> | void {
-    return this.render(req, res, view, data);
+    return this.render(req, res, req.next, view, data);
   }
 
-  private async render(req: AuthedRequest, res: Response, view: string, data: PageData): Promise<void> {
+  @asyncError
+  private async render(req: AuthedRequest, res: Response, next: NextFunction, view: string, data: PageData): Promise<void> {
     const constructedData: PageData = {...data, urls};
 
     if(this.featureFlags) {

--- a/src/main/controllers/UserResultsController.ts
+++ b/src/main/controllers/UserResultsController.ts
@@ -11,9 +11,11 @@ import {
 import autobind from 'autobind-decorator';
 import { User } from '../interfaces/User';
 import { SearchType } from '../utils/SearchType';
+import asyncError from '../modules/error-handler/asyncErrorDecorator';
 
 @autobind
 export class UserResultsController extends RootController {
+  @asyncError
   public async post(req: AuthedRequest, res: Response) {
     const input: string = req.body.search ?? '';
 

--- a/src/main/modules/error-handler/asyncErrorDecorator.ts
+++ b/src/main/modules/error-handler/asyncErrorDecorator.ts
@@ -1,0 +1,52 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function wrapMethod(
+  target: object,
+  key: string | symbol,
+  descriptor: TypedPropertyDescriptor<(req: Request, res: Response, next: NextFunction) => Promise<any>>
+) {
+  const fn = descriptor.value;
+
+  if (typeof fn !== 'function') {
+    throw new TypeError(`@wrapMethod decorator can only be applied to methods not: ${typeof fn}`);
+  }
+
+  descriptor.value = async function (...args) {
+    try {
+      // pass args to original function
+      await fn.apply(this, args);
+    } catch (err) {
+      // call next() function with err
+      args[2](err);
+    }
+  };
+
+  return descriptor;
+}
+
+
+export function wrapClass(target: any) {
+  Reflect.ownKeys(target.prototype).forEach(key => {
+    // Ignore constructor
+    if (key === 'constructor') {
+      return;
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(target.prototype, key);
+
+    // Only wrap functions
+    if (typeof descriptor.value === 'function') {
+      Object.defineProperty(target.prototype, key, wrapMethod(target, key, descriptor));
+    }
+  });
+
+  return target;
+}
+
+export default function asyncError(...args: any[]) {
+  if (args.length === 1) {
+    return wrapClass(args[0] as Function);
+  }
+
+  return wrapMethod(args[0], args[1], args[2]);
+}


### PR DESCRIPTION
### Change description ###

- Added class/method decorator `@asyncError` which will wrap a method/methods of a class with try/catch block to allow Express to handle thrown errors in async code. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
