### PR TITLE
edit-user - Updated edit user to match delete user controller style

### DIFF
--- a/src/main/controllers/UserActionsController.ts
+++ b/src/main/controllers/UserActionsController.ts
@@ -2,96 +2,17 @@ import { AuthedRequest } from '../interfaces/AuthedRequest';
 import { Response } from 'express';
 import { RootController } from './RootController';
 import autobind from 'autobind-decorator';
-import { User } from '../interfaces/User';
-import {
-  getObjectVariation,
-  hasProperty,
-  isEmpty,
-  isObjectEmpty,
-  isValidEmailFormat
-} from '../utils/utils';
-import {
-  INVALID_EMAIL_FORMAT_ERROR,
-  USER_EMPTY_EMAIL_ERROR,
-  USER_EMPTY_FORENAME_ERROR,
-  USER_EMPTY_SURNAME_ERROR,
-  USER_UPDATE_FAILED_ERROR,
-  USER_UPDATE_NO_CHANGE_ERROR
-} from '../utils/error';
 import asyncError from '../modules/error-handler/asyncErrorDecorator';
-import { PageError } from '../interfaces/PageData';
+import { EDIT_USER_URL } from '../utils/urls';
 
 @autobind
 export class UserActionsController extends RootController{
 
   @asyncError
   public post(req: AuthedRequest, res: Response) {
-    return req.scope.cradle.api.getUserById(req.body._userId)
-      .then((user) => {
-        switch (req.body._action) {
-          case 'save':
-            return this.saveUser(req, res, user);
-          case 'edit':
-            return this.editUser(req, res, user);
-        }});
-  }
-
-  private async saveUser(req: AuthedRequest, res: Response, user: User) {
-    const {_action, _csrf, _userId, ...editedUser} = req.body;
-
-    const {roles: originalRoles, ...originalFields} = user;
-    const {roles: editedRoles, ...editedFields} = editedUser as Partial<User>;
-
-    // No changes
-    const changedFields = this.comparePartialUsers(originalFields, editedFields);
-    if(isObjectEmpty(changedFields)) {
-      const error = { userEditForm: { message: USER_UPDATE_NO_CHANGE_ERROR }};
-      return super.post(req, res, 'edit-user', { content: { user }, error: error});
+    switch (req.body._action) {
+      case 'edit':
+        return res.redirect(307, EDIT_USER_URL);
     }
-
-    // Validation errors
-    const error = this.validateFields(changedFields);
-    if(!isObjectEmpty(error)) {
-      return super.post(req, res, 'edit-user', { content: { user: {...user, ...changedFields } }, error});
-    }
-
-    try {
-      let updatedUser = { ...originalFields, roles: originalRoles };
-      if(!isObjectEmpty(changedFields)) {
-        updatedUser = {
-          ...updatedUser,
-          ...await req.scope.cradle.api.editUserById(user.id, changedFields)
-        };
-      }
-
-      super.post(req, res, 'edit-user', { content: { user: updatedUser, notification: 'User saved successfully'}});
-    } catch (e) {
-      const error = { userEditForm: { message: USER_UPDATE_FAILED_ERROR + user.email } };
-      super.post(req, res, 'edit-user', { content: { user }, error } );
-    }
-  }
-
-  private async editUser(req: AuthedRequest, res: Response, user: User) {
-    super.post(req, res, 'edit-user', { content: { user } });
-  }
-
-  private comparePartialUsers(userA: Partial<User>, userB: Partial<User>) {
-    const variation = getObjectVariation(userA, userB).changed;
-    const changedFields: any = {};
-    variation.forEach(key => { changedFields[key] = (userB as any)[key]; } );
-
-    return changedFields;
-  }
-
-  private validateFields(fields: Partial<User>): PageError {
-    const { forename, surname, email } = fields;
-    const errors: any = {};
-
-    if(hasProperty(fields, 'forename') && isEmpty(forename)) errors.forename = { message: USER_EMPTY_FORENAME_ERROR };
-    if(hasProperty(fields, 'surname') && isEmpty(surname)) errors.surname = { message: USER_EMPTY_SURNAME_ERROR };
-    if(hasProperty(fields, 'email') && isEmpty(email)) errors.email = {message: USER_EMPTY_EMAIL_ERROR };
-    if(hasProperty(fields, 'email') && !isValidEmailFormat(email)) errors.email = {message: INVALID_EMAIL_FORMAT_ERROR };
-
-    return errors;
   }
 }

--- a/src/main/controllers/UserEditController.ts
+++ b/src/main/controllers/UserEditController.ts
@@ -1,0 +1,89 @@
+import autobind from 'autobind-decorator';
+import { Response } from 'express';
+import { RootController } from './RootController';
+import { AuthedRequest } from '../interfaces/AuthedRequest';
+import asyncError from '../modules/error-handler/asyncErrorDecorator';
+import { User } from '../interfaces/User';
+import { getObjectVariation, hasProperty, isEmpty, isObjectEmpty, isValidEmailFormat } from '../utils/utils';
+import {
+  INVALID_EMAIL_FORMAT_ERROR,
+  USER_EMPTY_EMAIL_ERROR,
+  USER_EMPTY_FORENAME_ERROR,
+  USER_EMPTY_SURNAME_ERROR,
+  USER_UPDATE_FAILED_ERROR,
+  USER_UPDATE_NO_CHANGE_ERROR
+} from '../utils/error';
+import { PageError } from '../interfaces/PageData';
+
+
+@autobind
+export class UserEditController extends RootController {
+
+  @asyncError
+  public post(req: AuthedRequest, res: Response) {
+    return req.scope.cradle.api.getUserById(req.body._userId)
+      .then(user => {
+
+        if(req.body._action === 'save') {
+          return this.saveUser(req, res, user);
+        }
+
+        return super.post(req, res, 'edit-user', { content: { user } });
+      });
+  }
+
+  private async saveUser(req: AuthedRequest, res: Response, user: User) {
+    const {_action, _csrf, _userId, ...editedUser} = req.body;
+
+    const {roles: originalRoles, ...originalFields} = user;
+    const {roles: editedRoles, ...editedFields} = editedUser as Partial<User>;
+
+    // No changes
+    const changedFields = this.comparePartialUsers(originalFields, editedFields);
+    if(isObjectEmpty(changedFields)) {
+      const error = { userEditForm: { message: USER_UPDATE_NO_CHANGE_ERROR }};
+      return super.post(req, res, 'edit-user', { content: { user }, error: error});
+    }
+
+    // Validation errors
+    const error = this.validateFields(changedFields);
+    if(!isObjectEmpty(error)) {
+      return super.post(req, res, 'edit-user', { content: { user: {...user, ...changedFields } }, error});
+    }
+
+    try {
+      let updatedUser = { ...originalFields, roles: originalRoles };
+      if(!isObjectEmpty(changedFields)) {
+        updatedUser = {
+          ...updatedUser,
+          ...await req.scope.cradle.api.editUserById(user.id, changedFields)
+        };
+      }
+
+      return super.post(req, res, 'edit-user', { content: { user: updatedUser, notification: 'User saved successfully'}});
+    } catch (e) {
+      const error = { userEditForm: { message: USER_UPDATE_FAILED_ERROR + user.email } };
+      return super.post(req, res, 'edit-user', { content: { user }, error } );
+    }
+  }
+
+  private comparePartialUsers(userA: Partial<User>, userB: Partial<User>) {
+    const variation = getObjectVariation(userA, userB).changed;
+    const changedFields: any = {};
+    variation.forEach(key => { changedFields[key] = (userB as any)[key]; } );
+
+    return changedFields;
+  }
+
+  private validateFields(fields: Partial<User>): PageError {
+    const { forename, surname, email } = fields;
+    const errors: PageError = {};
+
+    if(hasProperty(fields, 'forename') && isEmpty(forename)) errors.forename = { message: USER_EMPTY_FORENAME_ERROR };
+    if(hasProperty(fields, 'surname') && isEmpty(surname)) errors.surname = { message: USER_EMPTY_SURNAME_ERROR };
+    if(hasProperty(fields, 'email') && isEmpty(email)) errors.email = {message: USER_EMPTY_EMAIL_ERROR };
+    if(hasProperty(fields, 'email') && !isValidEmailFormat(email)) errors.email = {message: INVALID_EMAIL_FORMAT_ERROR };
+
+    return errors;
+  }
+}

--- a/src/main/modules/awilix/index.ts
+++ b/src/main/modules/awilix/index.ts
@@ -14,6 +14,7 @@ const logger = Logger.getLogger('app');
 import { defaultClient } from 'applicationinsights';
 import { IdamAuth } from '../../app/idam-auth/IdamAuth';
 import config from 'config';
+import { UserEditController } from '../../controllers/UserEditController';
 
 /**
  * Sets up the dependency injection container
@@ -30,6 +31,7 @@ export class Container {
       addUsersController: asClass(AddUsersController),
       addUserDetailsController: asClass(AddUserDetailsController),
       manageUsersController: asClass(ManageUsersController),
+      userEditController: asClass(UserEditController),
       userResultsController: asClass(UserResultsController),
       userActionsController: asClass(UserActionsController)
     });

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -2,6 +2,7 @@ import { Application } from 'express';
 import {
   ADD_USER_DETAILS_URL,
   ADD_USERS_URL,
+  EDIT_USER_URL,
   HOME_URL,
   MANAGER_USERS_URL,
   USER_ACTIONS_URL,
@@ -18,6 +19,7 @@ export default function(app: Application): void {
   app.get(ADD_USERS_URL, featureFlags.toggleRoute(BETA_FEATURES), app.locals.container.cradle.addUsersController.get);
   app.post(ADD_USER_DETAILS_URL, featureFlags.toggleRoute(BETA_FEATURES), app.locals.container.cradle.addUserDetailsController.post);
   app.get(MANAGER_USERS_URL, app.locals.container.cradle.manageUsersController.get);
+  app.post(EDIT_USER_URL, app.locals.container.cradle.userEditController.post);
   app.post(USER_RESULTS_URL, app.locals.container.cradle.userResultsController.post);
   app.post(USER_ACTIONS_URL, featureFlags.toggleRoute(BETA_FEATURES), app.locals.container.cradle.userActionsController.post);
 }

--- a/src/main/routes.ts
+++ b/src/main/routes.ts
@@ -19,7 +19,7 @@ export default function(app: Application): void {
   app.get(ADD_USERS_URL, featureFlags.toggleRoute(BETA_FEATURES), app.locals.container.cradle.addUsersController.get);
   app.post(ADD_USER_DETAILS_URL, featureFlags.toggleRoute(BETA_FEATURES), app.locals.container.cradle.addUserDetailsController.post);
   app.get(MANAGER_USERS_URL, app.locals.container.cradle.manageUsersController.get);
-  app.post(EDIT_USER_URL, app.locals.container.cradle.userEditController.post);
+  app.post(EDIT_USER_URL, featureFlags.toggleRoute(BETA_FEATURES), app.locals.container.cradle.userEditController.post);
   app.post(USER_RESULTS_URL, app.locals.container.cradle.userResultsController.post);
   app.post(USER_ACTIONS_URL, featureFlags.toggleRoute(BETA_FEATURES), app.locals.container.cradle.userActionsController.post);
 }

--- a/src/main/utils/urls.ts
+++ b/src/main/utils/urls.ts
@@ -9,6 +9,7 @@ export const ADD_USERS_URL = '/users/add';
 export const ADD_USER_DETAILS_URL = '/users/add/details';
 export const USER_DETAILS_URL = '/users/details';
 export const USER_ACTIONS_URL = '/users/actions';
+export const EDIT_USER_URL = '/users/edit';
 
 // Internal URLs
 export const USER_RESULTS_URL = '/user-results';

--- a/src/main/views/edit-user.njk
+++ b/src/main/views/edit-user.njk
@@ -37,7 +37,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Edit Users</h1>
     </div>
-    <form id="userEditForm" method="POST" action="{{ urls.USER_ACTIONS_URL }}">
+    <form id="userEditForm" method="POST" action="{{ urls.EDIT_USER_URL }}">
       {{ csrfProtection(csrfToken) }}
       <input type="hidden" name="_userId" value="{{ content.user.id }}">
       <div class="govuk-grid-column-one-half">

--- a/src/test/unit/test/controllers/UserActionsController.ts
+++ b/src/test/unit/test/controllers/UserActionsController.ts
@@ -1,179 +1,18 @@
-import { mockRequest } from '../../utils/mockRequest';
 import { mockResponse } from '../../utils/mockResponse';
-import * as urls from '../../../../main/utils/urls';
+import { mockRequest } from '../../utils/mockRequest';
 import { UserActionsController } from '../../../../main/controllers/UserActionsController';
-import { when } from 'jest-when';
-import { IdamAPI } from '../../../../main/app/idam-api/IdamAPI';
-
-type Mocked<T> = { [P in keyof T]: jest.Mock; };
+import { EDIT_USER_URL } from '../../../../main/utils/urls';
 
 describe('User actions controller', () => {
   let req: any;
   const res = mockResponse();
   const controller = new UserActionsController();
 
-  const mockApi: Mocked<IdamAPI> = {
-    getUserById: jest.fn(),
-    getUserDetails: jest.fn(),
-    editUserById: jest.fn()
-  };
+  beforeEach(() => req = mockRequest());
 
-  beforeEach(() => {
-    req = mockRequest();
-    req.scope.cradle.api = mockApi;
-  });
-
-  test('Should render the edit users page', async () => {
-    const postData = {
-      _userId: '7',
-      _action: 'edit'
-    };
-    const apiData = {
-      id: postData._userId,
-      forename: 'John',
-      surname: 'Smith',
-      email: 'john.smith@test.local',
-      active: true,
-      roles: ['IDAM_SUPER_USER'],
-    };
-
-    when(mockApi.getUserById).calledWith(postData._userId).mockReturnValue(Promise.resolve(apiData));
-    req.body = postData;
-
+  test('Should redirect to edit controller', async () => {
+    req.body = { _action: 'edit' };
     await controller.post(req, res);
-    expect(mockApi.getUserById).toBeCalledWith(postData._userId);
-    expect(res.render).toBeCalledWith('edit-user', { content: { user: apiData }, urls });
-  });
-
-  test('Should render the edit users page after saving', async () => {
-    const postData = {
-      _userId: '7',
-      _action: 'save',
-      id: '7',
-      forename: 'John',
-      surname: 'Smith',
-      email: 'john.smith@test.local',
-    };
-
-    const originalUserApiData = {
-      id: postData.id,
-      forename: 'Tom',
-      surname: postData.surname,
-      email: postData.email,
-      active: true,
-      roles: ['IDAM_SUPER_USER'],
-    };
-
-    const updatedUserApiData = {
-      id: postData.id,
-      forename: postData.forename,
-      surname: postData.surname,
-      email: postData.email,
-      active: true,
-      roles: ['IDAM_SUPER_USER'],
-    };
-
-    when(mockApi.getUserById).calledWith(postData._userId).mockReturnValue(Promise.resolve(originalUserApiData));
-    when(mockApi.editUserById).calledWith(postData._userId, { forename: postData.forename }).mockReturnValue(Promise.resolve(updatedUserApiData));
-    req.body = postData;
-
-    await controller.post(req, res);
-    expect(mockApi.getUserById).toBeCalledWith(postData._userId);
-    expect(mockApi.editUserById).toBeCalledWith(postData._userId, { forename: postData.forename });
-
-    expect(res.render).toBeCalledWith('edit-user', { content:  { user: updatedUserApiData, 'notification': 'User saved successfully' }, urls });
-  });
-
-  test('Should render the edit users page with validation errors after saving', async () => {
-    const originalUserData = {
-      id: '7',
-      forename: 'John',
-      surname: 'Smith',
-      email: 'john.smith@local.test',
-      active: true,
-      roles: ['IDAM_SUPER_USER'],
-    };
-
-    const updatedUserData = {
-      forename: '',
-      surname: '',
-      email: originalUserData.email,
-    };
-
-    const error = {
-      forename: { message: 'You must enter a forename for the user' },
-      surname: { message: 'You must enter a surname for the user' }
-    };
-
-
-    when(mockApi.getUserById).calledWith(originalUserData.id).mockReturnValue(Promise.resolve(originalUserData));
-    req.body = { _userId: originalUserData.id, _action: 'save', ...updatedUserData};
-    await controller.post(req, res);
-    expect(mockApi.getUserById).toBeCalledWith(originalUserData.id);
-
-    expect(res.render).toBeCalledWith('edit-user', { content: { user: {...originalUserData, ...updatedUserData} }, error, urls });
-  });
-
-  test('Should render the edit users page with errors when no fields changed', async () => {
-    const originalUserData = {
-      id: '7',
-      forename: 'John',
-      surname: 'Smith',
-      email: 'john.smith@local.test',
-      active: true,
-      roles: ['IDAM_SUPER_USER'],
-    };
-
-    const updatedUserData = {
-      forename: originalUserData.forename,
-      surname: originalUserData.surname,
-      email: originalUserData.email,
-    };
-
-    const error = {
-      userEditForm: { message: 'No changes to the user were made' },
-    };
-
-
-    when(mockApi.getUserById).calledWith(originalUserData.id).mockReturnValue(Promise.resolve(originalUserData));
-    req.body = { _userId: originalUserData.id, _action: 'save', ...updatedUserData};
-    await controller.post(req, res);
-    expect(mockApi.getUserById).toBeCalledWith(originalUserData.id);
-
-    expect(res.render).toBeCalledWith('edit-user', { content: { user: {...originalUserData, ...updatedUserData} }, error, urls });
-  });
-
-  test('Should render the edit users page after there was an API issue saving', async () => {
-    const postData = {
-      _userId: '7',
-      _action: 'save',
-      id: '7',
-      forename: 'John',
-      surname: 'Smith',
-      email: 'john.smith@test.local',
-    };
-
-    const originalUserApiData = {
-      id: postData.id,
-      forename: 'Tom',
-      surname: postData.surname,
-      email: postData.email,
-      active: true,
-      roles: ['IDAM_SUPER_USER'],
-    };
-
-    const error = {
-      userEditForm: { message: 'An error occurred whilst updating user ' + postData.email },
-    };
-
-    when(mockApi.getUserById).calledWith(postData._userId).mockReturnValue(Promise.resolve(originalUserApiData));
-    when(mockApi.editUserById).calledWith(postData._userId, { forename: postData.forename }).mockReturnValue(Promise.reject());
-    req.body = postData;
-
-    await controller.post(req, res);
-    expect(mockApi.getUserById).toBeCalledWith(postData._userId);
-    expect(mockApi.editUserById).toBeCalledWith(postData._userId, { forename: postData.forename });
-
-    expect(res.render).toBeCalledWith('edit-user', { content:  { user: originalUserApiData }, error, urls });
+    expect(res.redirect).toBeCalledWith(307, EDIT_USER_URL);
   });
 });

--- a/src/test/unit/test/controllers/UserEditController.ts
+++ b/src/test/unit/test/controllers/UserEditController.ts
@@ -1,0 +1,181 @@
+import { mockResponse } from '../../utils/mockResponse';
+import { IdamAPI } from '../../../../main/app/idam-api/IdamAPI';
+import { mockRequest } from '../../utils/mockRequest';
+import { when } from 'jest-when';
+import { UserEditController } from '../../../../main/controllers/UserEditController';
+import { mockRootController } from '../../utils/mockRootController';
+
+type Mocked<T> = { [P in keyof T]: jest.Mock; };
+
+describe('User edit controller', () => {
+  mockRootController();
+
+  let req: any;
+  const res = mockResponse();
+  const controller = new UserEditController();
+
+  const mockApi: Mocked<IdamAPI> = {
+    getUserById: jest.fn(),
+    getUserDetails: jest.fn(),
+    editUserById: jest.fn()
+  };
+
+  beforeEach(() => {
+    req = mockRequest();
+    req.scope.cradle.api = mockApi;
+  });
+
+  test('Should render the edit users page', async () => {
+    const postData = {
+      _userId: '7',
+      _action: 'edit'
+    };
+    const apiData = {
+      id: postData._userId,
+      forename: 'John',
+      surname: 'Smith',
+      email: 'john.smith@test.local',
+      active: true,
+      roles: ['IDAM_SUPER_USER'],
+    };
+
+    when(mockApi.getUserById).calledWith(postData._userId).mockReturnValue(Promise.resolve(apiData));
+    req.body = postData;
+
+    await controller.post(req, res);
+    expect(mockApi.getUserById).toBeCalledWith(postData._userId);
+    expect(res.render).toBeCalledWith('edit-user', { content: { user: apiData } });
+  });
+
+  test('Should render the edit users page after saving', async () => {
+    const postData = {
+      _userId: '7',
+      _action: 'save',
+      id: '7',
+      forename: 'John',
+      surname: 'Smith',
+      email: 'john.smith@test.local',
+    };
+
+    const originalUserApiData = {
+      id: postData.id,
+      forename: 'Tom',
+      surname: postData.surname,
+      email: postData.email,
+      active: true,
+      roles: ['IDAM_SUPER_USER'],
+    };
+
+    const updatedUserApiData = {
+      id: postData.id,
+      forename: postData.forename,
+      surname: postData.surname,
+      email: postData.email,
+      active: true,
+      roles: ['IDAM_SUPER_USER'],
+    };
+
+    when(mockApi.getUserById).calledWith(postData._userId).mockReturnValue(Promise.resolve(originalUserApiData));
+    when(mockApi.editUserById).calledWith(postData._userId, { forename: postData.forename }).mockReturnValue(Promise.resolve(updatedUserApiData));
+    req.body = postData;
+
+    await controller.post(req, res);
+    expect(mockApi.getUserById).toBeCalledWith(postData._userId);
+    expect(mockApi.editUserById).toBeCalledWith(postData._userId, { forename: postData.forename });
+
+    expect(res.render).toBeCalledWith('edit-user', { content:  { user: updatedUserApiData, 'notification': 'User saved successfully' } });
+  });
+
+  test('Should render the edit users page with validation errors after saving', async () => {
+    const originalUserData = {
+      id: '7',
+      forename: 'John',
+      surname: 'Smith',
+      email: 'john.smith@local.test',
+      active: true,
+      roles: ['IDAM_SUPER_USER'],
+    };
+
+    const updatedUserData = {
+      forename: '',
+      surname: '',
+      email: originalUserData.email,
+    };
+
+    const error = {
+      forename: { message: 'You must enter a forename for the user' },
+      surname: { message: 'You must enter a surname for the user' }
+    };
+
+
+    when(mockApi.getUserById).calledWith(originalUserData.id).mockReturnValue(Promise.resolve(originalUserData));
+    req.body = { _userId: originalUserData.id, _action: 'save', ...updatedUserData};
+    await controller.post(req, res);
+    expect(mockApi.getUserById).toBeCalledWith(originalUserData.id);
+
+    expect(res.render).toBeCalledWith('edit-user', { content: { user: {...originalUserData, ...updatedUserData} }, error });
+  });
+
+  test('Should render the edit users page with errors when no fields changed', async () => {
+    const originalUserData = {
+      id: '7',
+      forename: 'John',
+      surname: 'Smith',
+      email: 'john.smith@local.test',
+      active: true,
+      roles: ['IDAM_SUPER_USER'],
+    };
+
+    const updatedUserData = {
+      forename: originalUserData.forename,
+      surname: originalUserData.surname,
+      email: originalUserData.email,
+    };
+
+    const error = {
+      userEditForm: { message: 'No changes to the user were made' },
+    };
+
+
+    when(mockApi.getUserById).calledWith(originalUserData.id).mockReturnValue(Promise.resolve(originalUserData));
+    req.body = { _userId: originalUserData.id, _action: 'save', ...updatedUserData};
+    await controller.post(req, res);
+    expect(mockApi.getUserById).toBeCalledWith(originalUserData.id);
+
+    expect(res.render).toBeCalledWith('edit-user', { content: { user: {...originalUserData, ...updatedUserData} }, error });
+  });
+
+  test('Should render the edit users page after there was an API issue saving', async () => {
+    const postData = {
+      _userId: '7',
+      _action: 'save',
+      id: '7',
+      forename: 'John',
+      surname: 'Smith',
+      email: 'john.smith@test.local',
+    };
+
+    const originalUserApiData = {
+      id: postData.id,
+      forename: 'Tom',
+      surname: postData.surname,
+      email: postData.email,
+      active: true,
+      roles: ['IDAM_SUPER_USER'],
+    };
+
+    const error = {
+      userEditForm: { message: 'An error occurred whilst updating user ' + postData.email },
+    };
+
+    when(mockApi.getUserById).calledWith(postData._userId).mockReturnValue(Promise.resolve(originalUserApiData));
+    when(mockApi.editUserById).calledWith(postData._userId, { forename: postData.forename }).mockReturnValue(Promise.reject());
+    req.body = postData;
+
+    await controller.post(req, res);
+    expect(mockApi.getUserById).toBeCalledWith(postData._userId);
+    expect(mockApi.editUserById).toBeCalledWith(postData._userId, { forename: postData.forename });
+
+    expect(res.render).toBeCalledWith('edit-user', { content:  { user: originalUserApiData }, error });
+  });
+});

--- a/src/test/unit/utils/mockRootController.ts
+++ b/src/test/unit/utils/mockRootController.ts
@@ -1,0 +1,11 @@
+import { RootController } from '../../../main/controllers/RootController';
+
+export const mockRootController = () => {
+  jest.spyOn(RootController.prototype, 'get').mockImplementation((req, res, view, data) => {
+    res.render(view, data);
+  });
+
+  jest.spyOn(RootController.prototype, 'post').mockImplementation((req, res, view, data) => {
+    res.render(view, data);
+  });
+};


### PR DESCRIPTION
### Change description ###

- Updated edit user to not be inside UserActionsController but instead inside UserEditController, in-line with how it's done for user delete.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
