### PR TITLE
Fix for cross browser tests not using helpers from main config

### DIFF
--- a/src/test/cross-browser/saucelabs.conf.ts
+++ b/src/test/cross-browser/saucelabs.conf.ts
@@ -40,6 +40,7 @@ const setupConfig = {
   name: 'cross-browser',
   output: '../../../functional-output/cross-browser/reports',
   helpers: {
+    ...config.helpers,
     Playwright: {
       url: config.TEST_URL,
       browser: 'chromium',
@@ -49,9 +50,6 @@ const setupConfig = {
       host: 'ondemand.eu-central-1.saucelabs.com',
       port: 80,
       capabilities: {},
-    },
-    FeatureFlagHelper: {
-      require: '../functional/shared/helpers/featureFlagHelper.ts'
     },
   },
   plugins: {


### PR DESCRIPTION
### Change description ###

- Fix for helpers in main test config not being used in crossbrowser tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
