### PR TITLE
Changed deleteAllTestData to use async

### DIFF
--- a/src/test/functional/shared/testingSupportApi.ts
+++ b/src/test/functional/shared/testingSupportApi.ts
@@ -153,7 +153,7 @@ export const deleteUser = async (email) => {
   }
 };
 
-export const deleteAllTestData = async (testDataPrefix = '', userNames = [], roleNames = [], serviceNames = [], async = false) => {
+export const deleteAllTestData = async (testDataPrefix = '', userNames = [], roleNames = [], serviceNames = [], async = true) => {
   try {
     await axios.delete(
       `${config.get('services.idam.url.api')}/testing-support/test-data?async=${async}&userNames=${userNames.join(',')}&roleNames=${roleNames.join(',')}&testDataPrefix=${testDataPrefix}&serviceNames=${serviceNames.join(',')}`


### PR DESCRIPTION
### Change description ###

- Provided async argument to `/testing-support/test-data` due to connection timing out before test-data is all cleared.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
