### PR TITLE
CVE-2021-44906 Update version for miminist dependency to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     "webpack-node-externals": "^3.0.0"
   },
   "resolutions": {
-    "applicationinsights/@azure/core-http/node-fetch": "^2.6.7"
+    "applicationinsights/@azure/core-http/node-fetch": "^2.6.7",
+    "tsconfig-paths/minimist": "1.2.6",
+    "config/json5/minimist": "1.2.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6707,10 +6707,10 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### JIRA link ###



### Change description ###

Update version for miminist dependency to fix security vulnerability CVE-2021-44906

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
