### PR TITLE
Fixed helmet and removed unused GA stuff

### DIFF
--- a/src/main/modules/helmet/index.ts
+++ b/src/main/modules/helmet/index.ts
@@ -5,7 +5,6 @@ export interface HelmetConfig {
   referrerPolicy: string;
 }
 
-const googleAnalyticsDomain = '*.google-analytics.com';
 const self = "'self'";
 
 /**
@@ -23,6 +22,13 @@ export class Helmet {
   }
 
   private setContentSecurityPolicy(app: express.Express): void {
+    const scriptSrc = [self];
+
+    if (app.locals.ENV === 'development') {
+      scriptSrc.push("'unsafe-inline'");
+      scriptSrc.push("'unsafe-eval'");
+    }
+
     app.use(
       helmet.contentSecurityPolicy({
         useDefaults: false,
@@ -30,9 +36,9 @@ export class Helmet {
           connectSrc: [self],
           defaultSrc: ["'none'"],
           fontSrc: [self, 'data:'],
-          imgSrc: [self, googleAnalyticsDomain],
+          imgSrc: [self],
           objectSrc: [self],
-          scriptSrc: [self, googleAnalyticsDomain, "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"],
+          scriptSrc: scriptSrc,
           styleSrc: [self]
         }
       })

--- a/src/main/views/template.njk
+++ b/src/main/views/template.njk
@@ -53,24 +53,6 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script>
-    function pushToDataLayer(selection, pageName) {
-      const buttons = document.getElementsByName(selection);
-      for (let i = 0; i < buttons.length; i++) {
-        if (buttons[i].checked) {
-          const val_id = buttons[i].id;
-          const selector = 'label[for=' + val_id + ']';
-          const label = document.querySelector(selector);
-          const label_text = label.innerText;
-          window.dataLayer.push({
-            'event': 'Page selections',
-            'Page': pageName ,
-            'selection': label_text,
-          });
-        }
-      }
-    }
-  </script>
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   {% include "webpack/js.njk" %}
 {% endblock %}


### PR DESCRIPTION
### Change description ###

- Fixed helmet to allow for unsafe-eval/unsafe-inline on development builds. Webpack uses 'eval' for creating sourcemaps etc. on local development builds, and this stops the JS from being executed correctly on local.
-Removed unused Google Analytics code

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
