### PR TITLE
Cleanup unit tests - Updated old unit tests to use mockRootController

### DIFF
--- a/src/test/unit/test/controllers/AddUserDetailsController.ts
+++ b/src/test/unit/test/controllers/AddUserDetailsController.ts
@@ -1,6 +1,5 @@
 import { mockResponse } from '../../utils/mockResponse';
 import { mockRequest } from '../../utils/mockRequest';
-import * as urls from '../../../../main/utils/urls';
 import { AddUserDetailsController } from '../../../../main/controllers/AddUserDetailsController';
 import {
   duplicatedEmailError,
@@ -12,9 +11,11 @@ import {
 } from '../../../../main/utils/error';
 import { when } from 'jest-when';
 import { UserType } from '../../../../main/utils/UserType';
+import { mockRootController } from '../../utils/mockRootController';
 import { mockApi } from '../../utils/mockApi';
 
 describe('Add user details controller', () => {
+  mockRootController();
   let req: any;
   const res = mockResponse();
   const controller = new AddUserDetailsController();
@@ -41,11 +42,7 @@ describe('Add user details controller', () => {
     req.scope.cradle.api = mockApi;
 
     await controller.post(req, res);
-    expect(res.render).toBeCalledWith('add-user-details', {
-      content: {
-        user: {email: email}
-      },
-      urls
+    expect(res.render).toBeCalledWith('add-user-details', { content: { user: { email } },
     });
   });
 
@@ -70,7 +67,6 @@ describe('Add user details controller', () => {
       error: { email: {
         message: duplicatedEmailError(email)
       }},
-      urls
     });
   });
 
@@ -82,7 +78,6 @@ describe('Add user details controller', () => {
       error: { email: {
         message: MISSING_EMAIL_ERROR
       }},
-      urls
     });
   });
 
@@ -94,7 +89,6 @@ describe('Add user details controller', () => {
       error: { email: {
         message: MISSING_EMAIL_ERROR
       }},
-      urls
     });
   });
 
@@ -106,7 +100,6 @@ describe('Add user details controller', () => {
       error: { email: {
         message: INVALID_EMAIL_FORMAT_ERROR
       }},
-      urls
     });
   });
 
@@ -130,7 +123,6 @@ describe('Add user details controller', () => {
       error: { forename: {
         message: USER_EMPTY_FORENAME_ERROR
       }},
-      urls
     });
   });
 
@@ -154,7 +146,6 @@ describe('Add user details controller', () => {
       error: { surname: {
         message: USER_EMPTY_SURNAME_ERROR
       }},
-      urls
     });
   });
 
@@ -177,7 +168,6 @@ describe('Add user details controller', () => {
       },
       error: { forename: { message: USER_EMPTY_FORENAME_ERROR },
         surname: { message: USER_EMPTY_SURNAME_ERROR } },
-      urls
     });
   });
 
@@ -200,7 +190,6 @@ describe('Add user details controller', () => {
       error: { userType: {
         message: MISSING_USER_TYPE_ERROR
       }},
-      urls
     });
   });
 
@@ -254,8 +243,6 @@ describe('Add user details controller', () => {
     await controller.post(req, res);
     expect(res.render).toBeCalledWith('add-user-roles', {
       content: expectedContent,
-      urls,
-      user: { assignableRoles: [] }
     });
   });
 });

--- a/src/test/unit/test/controllers/AddUserRolesController.ts
+++ b/src/test/unit/test/controllers/AddUserRolesController.ts
@@ -1,15 +1,16 @@
 import {when} from 'jest-when';
-import * as urls from '../../../../main/utils/urls';
 import { mockResponse } from '../../utils/mockResponse';
 import { AddUserRolesController } from '../../../../main/controllers/AddUserRolesController';
 import { mockRequest } from '../../utils/mockRequest';
 import {MISSING_ROLE_ASSIGNMENT_ERROR} from '../../../../main/utils/error';
 import {mockApi} from '../../utils/mockApi';
+import { mockRootController } from '../../utils/mockRootController';
 
 describe('Add user roles controller', () => {
   let req: any;
   const res = mockResponse();
   const controller = new AddUserRolesController();
+  mockRootController();
 
   const email = 'test@test.com';
   const forename = 'test';
@@ -38,7 +39,7 @@ describe('Add user roles controller', () => {
     req.body.roles = role;
 
     await controller.post(req, res);
-    expect(res.render).toBeCalledWith('add-user-completion', { urls });
+    expect(res.render).toBeCalledWith('add-user-completion');
   });
 
   test('Should render the add user completion page when assigning the user with multiple roles', async () => {
@@ -57,7 +58,7 @@ describe('Add user roles controller', () => {
     req.body.roles = roleArray;
 
     await controller.post(req, res);
-    expect(res.render).toBeCalledWith('add-user-completion', { urls });
+    expect(res.render).toBeCalledWith('add-user-completion');
   });
 
   test('Should render the add user roles page with error when no role assigned to the user', async () => {
@@ -103,9 +104,7 @@ describe('Add user roles controller', () => {
     await controller.post(req, res);
     expect(res.render).toBeCalledWith('add-user-roles', {
       content: expectedRoleAssignment,
-      error: expectedError,
-      urls,
-      user: { assignableRoles: [role2] }
+      error: expectedError
     });
   });
 });

--- a/src/test/unit/test/controllers/AddUsersController.ts
+++ b/src/test/unit/test/controllers/AddUsersController.ts
@@ -1,9 +1,10 @@
 import { AddUserController } from '../../../../main/controllers/AddUserController';
 import { mockRequest } from '../../utils/mockRequest';
 import { mockResponse } from '../../utils/mockResponse';
-import * as urls from '../../../../main/utils/urls';
+import { mockRootController } from '../../utils/mockRootController';
 
 describe('Add user controller', () => {
+  mockRootController();
   let req: any;
   const res = mockResponse();
   const controller = new AddUserController();
@@ -14,6 +15,6 @@ describe('Add user controller', () => {
 
   test('Should render the add user page', async () => {
     await controller.get(req, res);
-    expect(res.render).toBeCalledWith('add-user', { urls });
+    expect(res.render).toBeCalledWith('add-user');
   });
 });

--- a/src/test/unit/test/controllers/ManageUserController.ts
+++ b/src/test/unit/test/controllers/ManageUserController.ts
@@ -1,9 +1,10 @@
 import { ManageUserController } from '../../../../main/controllers/ManageUserController';
 import { mockRequest } from '../../utils/mockRequest';
 import { mockResponse } from '../../utils/mockResponse';
-import * as urls from '../../../../main/utils/urls';
+import { mockRootController } from '../../utils/mockRootController';
 
 describe('Manage user controller', () => {
+  mockRootController();
   let req: any;
   const res = mockResponse();
   const controller = new ManageUserController();
@@ -14,6 +15,6 @@ describe('Manage user controller', () => {
 
   test('Should render the manage user page', async () => {
     await controller.get(req, res);
-    expect(res.render).toBeCalledWith('manage-user', { urls });
+    expect(res.render).toBeCalledWith('manage-user');
   });
 });

--- a/src/test/unit/test/controllers/UserOptionController.ts
+++ b/src/test/unit/test/controllers/UserOptionController.ts
@@ -4,8 +4,10 @@ import { mockResponse } from '../../utils/mockResponse';
 import { PageData } from '../../../../main/interfaces/PageData';
 import { MISSING_OPTION_ERROR } from '../../../../main/utils/error';
 import * as urls from '../../../../main/utils/urls';
+import { mockRootController } from '../../utils/mockRootController';
 
 describe('User option controller', () => {
+  mockRootController();
   let req: any;
   const res = mockResponse();
   const controller = new UserOptionController();
@@ -16,14 +18,13 @@ describe('User option controller', () => {
 
   test('Should render the user option page', async () => {
     await controller.get(req, res);
-    expect(res.render).toBeCalledWith('user-option', { urls} );
+    expect(res.render).toBeCalledWith('user-option' );
   });
 
   test('Should render the user option page with error when posting with no option selected', async () => {
     await controller.post(req, res);
     const expectedPageData: PageData = {
       error: { userAction: { message: MISSING_OPTION_ERROR }},
-      urls
     };
 
     expect(res.render).toBeCalledWith('user-option', expectedPageData);

--- a/src/test/unit/utils/mockRootController.ts
+++ b/src/test/unit/utils/mockRootController.ts
@@ -2,10 +2,10 @@ import { RootController } from '../../../main/controllers/RootController';
 
 export const mockRootController = () => {
   jest.spyOn(RootController.prototype, 'get').mockImplementation((req, res, view, data) => {
-    res.render(view, data);
+    data ? res.render(view, data) : res.render(view);
   });
 
   jest.spyOn(RootController.prototype, 'post').mockImplementation((req, res, view, data) => {
-    res.render(view, data);
+    data ? res.render(view, data) : res.render(view);
   });
 };


### PR DESCRIPTION
### Change description ###

- Updated old/outdated unit tests to use the recently introduced mockRootController

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
