### PR TITLE
Changed user details to be fulfilled by data from searching user by ID

### DIFF
--- a/src/main/controllers/UserResultsController.ts
+++ b/src/main/controllers/UserResultsController.ts
@@ -25,7 +25,8 @@ export class UserResultsController extends RootController {
 
     if (users) {
       if (users.length === 1) {
-        const user = users[0];
+        const user = await req.scope.cradle.api.getUserById(users[0].id);
+
         this.preprocessSearchResults(user);
         return super.post(req, res, 'user-details', {
           content: { user, showDelete: this.canDeleteUser(req.session.user, user)}

--- a/src/test/unit/test/controllers/UserResultsController.ts
+++ b/src/test/unit/test/controllers/UserResultsController.ts
@@ -40,6 +40,7 @@ describe('User results controller', () => {
       }
     ];
     when(mockApi.searchUsersByEmail).calledWith(email).mockResolvedValue(results);
+    when(mockApi.getUserById).calledWith(userId).mockResolvedValue(results[0]);
 
     req.body.search = email;
     req.scope.cradle.api = mockApi;
@@ -85,6 +86,7 @@ describe('User results controller', () => {
       }
     ];
     when(mockApi.getUserById).calledWith(ssoId).mockRejectedValue('');
+    when(mockApi.getUserById).calledWith(userId).mockResolvedValue(results[0]);
     when(mockApi.searchUsersBySsoId).calledWith(ssoId).mockResolvedValue(results);
 
     req.body.search = ssoId;

--- a/src/test/unit/test/controllers/UserResultsController.ts
+++ b/src/test/unit/test/controllers/UserResultsController.ts
@@ -39,7 +39,7 @@ describe('User results controller', () => {
         ssoId: ssoId
       }
     ];
-    when(mockApi.searchUsersByEmail).calledWith(email).mockReturnValue(results);
+    when(mockApi.searchUsersByEmail).calledWith(email).mockResolvedValue(results);
 
     req.body.search = email;
     req.scope.cradle.api = mockApi;
@@ -49,27 +49,25 @@ describe('User results controller', () => {
   });
 
   test('Should render the user details page when searching with a valid user ID', async () => {
-    const results = [
-      {
-        id: userId,
-        forename: 'John',
-        surname: 'Smith',
-        email: email,
-        active: true,
-        roles: ['IDAM_SUPER_USER'],
-        ssoId: ssoId,
-        createDate: '',
-        lastModified: ''
-      }
-    ];
-    when(mockApi.getUserById).calledWith(userId).mockReturnValue(results);
-    when(mockApi.searchUsersBySsoId).calledWith(userId).mockReturnValue([]);
+    const results = {
+      id: userId,
+      forename: 'John',
+      surname: 'Smith',
+      email: email,
+      active: true,
+      roles: ['IDAM_SUPER_USER'],
+      ssoId: ssoId,
+      createDate: '',
+      lastModified: ''
+    };
+    when(mockApi.getUserById).calledWith(userId).mockResolvedValue(results);
+    when(mockApi.searchUsersBySsoId).calledWith(userId).mockResolvedValue([]);
 
     req.body.search = userId;
     req.scope.cradle.api = mockApi;
     req.session = { user: { assignableRoles: [] } };
     await controller.post(req, res);
-    expect(res.render).toBeCalledWith('user-details', { content: { user: results[0], showDelete: false } });
+    expect(res.render).toBeCalledWith('user-details', { content: { user: results, showDelete: false } });
   });
 
   test('Should render the user details page when searching with a valid SSO ID', async () => {
@@ -86,8 +84,8 @@ describe('User results controller', () => {
         lastModified: ''
       }
     ];
-    when(mockApi.getUserById).calledWith(ssoId).mockReturnValue([]);
-    when(mockApi.searchUsersBySsoId).calledWith(ssoId).mockReturnValue(results);
+    when(mockApi.getUserById).calledWith(ssoId).mockRejectedValue('');
+    when(mockApi.searchUsersBySsoId).calledWith(ssoId).mockResolvedValue(results);
 
     req.body.search = ssoId;
     req.scope.cradle.api = mockApi;
@@ -106,8 +104,8 @@ describe('User results controller', () => {
   });
 
   test('Should render the manage user page when searching with a non-existent ID', async () => {
-    when(mockApi.getUserById).calledWith(userId).mockReturnValue(Promise.reject('Not found'));
-    when(mockApi.searchUsersBySsoId).calledWith(userId).mockReturnValue([]);
+    when(mockApi.getUserById).calledWith(userId).mockRejectedValue('');
+    when(mockApi.searchUsersBySsoId).calledWith(userId).mockResolvedValue([]);
 
     req.body.search = userId;
     req.scope.cradle.api = mockApi;
@@ -136,7 +134,7 @@ describe('User results controller', () => {
         ssoId: userId
       }
     ];
-    when(mockApi.searchUsersByEmail).calledWith(email).mockReturnValue(results);
+    when(mockApi.searchUsersByEmail).calledWith(email).mockResolvedValue(results);
 
     req.body.search = email;
     req.scope.cradle.api = mockApi;
@@ -165,8 +163,8 @@ describe('User results controller', () => {
         ssoId: ssoId
       }
     ];
-    when(mockApi.getUserById).calledWith(ssoId).mockReturnValue(Promise.reject('Not found'));
-    when(mockApi.searchUsersBySsoId).calledWith(ssoId).mockReturnValue(results);
+    when(mockApi.getUserById).calledWith(ssoId).mockRejectedValue('');
+    when(mockApi.searchUsersBySsoId).calledWith(ssoId).mockResolvedValue(results);
 
     req.body.search = ssoId;
     req.scope.cradle.api = mockApi;


### PR DESCRIPTION
### Change description ###

- Requested by @nikola-naydenov-hmcts, change required for supporting 'locked' field
- User details screen now has its details filled by a call to `/api/v1/users/:userId`
- Fixed issues where unit tests weren't correctly using promise based values when mocking function returns.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
