### PR TITLE
SIDM-7622 - Re-added use of /o/endSession for logging out

### DIFF
--- a/src/main/app/idam-api/IdamAPI.ts
+++ b/src/main/app/idam-api/IdamAPI.ts
@@ -79,7 +79,7 @@ export class IdamAPI {
       .post('/api/v1/users/registration', user)
       .then(results => results.data)
       .catch(error => {
-        const errorMessage = error.response.status === 403 ? ROLE_PERMISSION_ERROR :'Error register new user in IDAM API';
+        const errorMessage = error.response?.status === 403 ? ROLE_PERMISSION_ERROR :'Error register new user in IDAM API';
         this.telemetryClient.trackTrace({message: errorMessage});
         this.logger.error(`${error.stack || error}`);
         return Promise.reject(errorMessage);

--- a/src/main/app/idam-auth/OIDCToken.ts
+++ b/src/main/app/idam-auth/OIDCToken.ts
@@ -7,9 +7,9 @@ export class OIDCToken {
 }
 
 export interface OIDCToken {
-  [key: string]: string | number | boolean;
-  exp: number;
-  iat: number;
-  expires_in: number;
+  [key: string]: any;
+  exp?: number;
+  iat?: number;
+  expires_in?: number;
   raw: string;
 }

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -32,10 +32,11 @@ export class OidcMiddleware {
 
     app.get(LOGOUT_URL, (req: AuthedRequest, res: Response) => {
       if (!req.session.user) return res.redirect(LOGIN_URL);
+      const idToken = req.session.tokens.idToken;
 
       req.session.destroy(() => {
         res.clearCookie(config.get('session.cookie.name'));
-        res.redirect(LOGIN_URL);
+        res.redirect(idamAuth.getEndSessionRedirect(idToken));
       });
     });
 

--- a/src/test/unit/test/app/idam-api/IdamAPI.ts
+++ b/src/test/unit/test/app/idam-api/IdamAPI.ts
@@ -334,12 +334,10 @@ describe('IdamAPI', () => {
     test('Should not register a user when error', () => {
       const mockAxios = {post: () => Promise.reject('')} as any;
       const mockLogger = {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        error : () => {}
+        error: jest.fn()
       } as any;
       const mockTelemetryClient = {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        trackTrace : () => {}
+        trackTrace: jest.fn()
       } as any;
       const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/SIDM-7622

### Change description ###

- Added function to build /o/endSession endpoint redirect when a user is logging out
- Fixed issue with some unit tests 
- Added unit tests for un-covered IdamAuth

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
