### PR TITLE
SIDM-6594 Allow registering of onboarding users without 'private-beta' in onboarding roles

### DIFF
--- a/src/main/controllers/AddPrivateBetaServiceController.ts
+++ b/src/main/controllers/AddPrivateBetaServiceController.ts
@@ -47,7 +47,7 @@ export class AddPrivateBetaServiceController extends RootController {
       });
   }
 
-  private async getRolesToRegisterUser(req: AuthedRequest, allServices: Service[], serviceField: String): Promise<string[]> {
+  private async getRolesToRegisterUser(req: AuthedRequest, allServices: Service[], serviceField: string): Promise<string[]> {
     const selectedService = allServices.find(service => service.label === serviceField);
     const rolesToAdd: string[] = [UserType.Citizen];
 
@@ -59,7 +59,7 @@ export class AddPrivateBetaServiceController extends RootController {
 
     selectedService.onboardingRoles.forEach(r => {
       if (rolesMap.has(r)) {
-        rolesToAdd.push(rolesMap.get(r).name)
+        rolesToAdd.push(rolesMap.get(r).name);
       }
     });
     return rolesToAdd;

--- a/src/main/utils/serviceUtils.ts
+++ b/src/main/utils/serviceUtils.ts
@@ -1,15 +1,12 @@
 import { SelectItem } from '../interfaces/SelectItem';
 import { Service } from '../interfaces/Service';
-import { arrayContainsSubstring } from './utils';
-
-export const PRIVATE_BETA_ROLE = 'private-beta';
 
 const getServicesWithPrivateBetaRole = (services: Service[]): Service[] => {
-  return services.filter(service => service.onboardingRoles.length > 0 && arrayContainsSubstring(service.onboardingRoles, PRIVATE_BETA_ROLE));
+  return services.filter(service => service.onboardingRoles.length > 0);
 };
 
 export const hasPrivateBetaServices = (services: Service[]): boolean => {
-  return services.some(service => service.onboardingRoles.length > 0 && arrayContainsSubstring(service.onboardingRoles, PRIVATE_BETA_ROLE));
+  return services.some(service => service.onboardingRoles.length > 0);
 };
 
 export const getServicesForSelect = (services: Service[]): SelectItem[] => {

--- a/src/test/functional/register-user-test.ts
+++ b/src/test/functional/register-user-test.ts
@@ -9,7 +9,6 @@ import {config as testConfig} from '../config';
 import * as Assert from 'assert';
 import {randomData} from './shared/random-data';
 import {BETA_ADD, GAMMA_PRIVATE_BETA} from '../../main/app/feature-flags/flags';
-import {PRIVATE_BETA_ROLE} from '../../main/utils/serviceUtils';
 import {UserType} from '../../main/utils/UserType';
 
 Feature('Register New User');
@@ -19,7 +18,7 @@ const ASSIGNABLE_CHILD_ROLE1 = randomData.getRandomRole();
 const ASSIGNABLE_CHILD_ROLE2 = randomData.getRandomRole();
 const DASHBOARD_USER_EMAIL = randomData.getRandomEmailAddress();
 const SERVICE_WITH_PRIVATE_BETA = randomData.getRandomRole();
-const PRIVATE_BETA_USER_ROLE = SERVICE_WITH_PRIVATE_BETA + '-' + PRIVATE_BETA_ROLE;
+const PRIVATE_BETA_USER_ROLE = SERVICE_WITH_PRIVATE_BETA + '-beta-role';
 
 const OAUTH_REDIRECT_URI = 'http://test.com/oauth2/callback';
 

--- a/src/test/unit/test/controllers/AddPrivateBetaServiceController.ts
+++ b/src/test/unit/test/controllers/AddPrivateBetaServiceController.ts
@@ -19,7 +19,12 @@ describe('Add private beta service controller', () => {
 
   const service1 = 'service1';
   const service2 = 'service2';
-  const privateBetaRole = 'service-private-beta';
+  const privateBetaRoleId = '1';
+  const privateBetaRoleName = 'service-private-beta';
+  const otherRoleId1 = '2';
+  const otherRoleName1 = 'other-role1';
+  const otherRoleId2 = '3';
+  const otherRoleName2 = 'other-role2';
 
   const error = 'error';
 
@@ -27,12 +32,27 @@ describe('Add private beta service controller', () => {
     {
       label: service1,
       description: service1,
-      onboardingRoles: [privateBetaRole]
+      onboardingRoles: [privateBetaRoleId]
     },
     {
       label: service2,
       description: service2,
-      onboardingRoles: [privateBetaRole]
+      onboardingRoles: [privateBetaRoleId]
+    }
+  ];
+
+  const allRoles = [
+    {
+      id: privateBetaRoleId,
+      name: privateBetaRoleName
+    },
+    {
+      id: otherRoleId1,
+      name: otherRoleName1
+    },
+    {
+      id: otherRoleId2,
+      name: otherRoleName2
     }
   ];
 
@@ -46,10 +66,11 @@ describe('Add private beta service controller', () => {
       email: email,
       firstName: forename,
       lastName: surname,
-      roles: [UserType.Citizen, privateBetaRole]
+      roles: [UserType.Citizen, privateBetaRoleName]
     };
 
     when(mockApi.getAllServices).calledWith().mockReturnValue(services);
+    when(mockApi.getAllRoles).calledWith().mockReturnValue(allRoles);
     when(mockApi.registerUser).calledWith(userRegistrationDetails).mockResolvedValue({});
 
     req.body = {
@@ -68,10 +89,11 @@ describe('Add private beta service controller', () => {
       email: email,
       firstName: forename,
       lastName: surname,
-      roles: [UserType.Citizen, privateBetaRole]
+      roles: [UserType.Citizen, privateBetaRoleName]
     };
 
     when(mockApi.getAllServices).calledWith().mockReturnValue(services);
+    when(mockApi.getAllRoles).calledWith().mockReturnValue(allRoles);
     when(mockApi.registerUser).calledWith(userRegistrationDetails).mockReturnValue(Promise.reject(error));
 
     req.body = {

--- a/src/test/unit/test/utils/serviceUtils.ts
+++ b/src/test/unit/test/utils/serviceUtils.ts
@@ -10,12 +10,11 @@ describe('serviceUtils', () => {
   const service3 = 'Service3';
   const service4 = 'Service4';
   const service5 = 'Service5';
-  const privateBetaRole = 'service-private-beta';
-  const otherRole1 = 'other1';
-  const otherRole2 = 'other2';
+  const role1 = 'other1';
+  const role2 = 'other2';
 
   describe('hasPrivateBetaServices', () => {
-    test('Should return true when one of the services has "private-beta" onboarding roles', async () => {
+    test('Should return true when one of the services has onboarding roles', async () => {
       const testServices: Service[] = [
         {
           label: service1,
@@ -26,30 +25,20 @@ describe('serviceUtils', () => {
           label: service2,
           description: service2,
           onboardingRoles: [
-            otherRole1,
-            privateBetaRole
+            role1
           ]
         },
         {
           label: service3,
           description: service3,
-          onboardingRoles: [
-            otherRole1
-          ]
-        },
-        {
-          label: service4,
-          description: service4,
-          onboardingRoles: [
-            otherRole2
-          ]
+          onboardingRoles: []
         }
       ];
 
       expect(hasPrivateBetaServices(testServices)).toBeTruthy();
     });
 
-    test('Should return false when none of the services has "private-beta" onboarding roles', async () => {
+    test('Should return false when none of the services has onboarding roles', async () => {
       const testServices: Service[] = [
         {
           label: service1,
@@ -59,17 +48,12 @@ describe('serviceUtils', () => {
         {
           label: service2,
           description: service2,
-          onboardingRoles: [
-            otherRole1,
-            otherRole2
-          ]
+          onboardingRoles: []
         },
         {
           label: service3,
           description: service3,
-          onboardingRoles: [
-            otherRole1
-          ]
+          onboardingRoles: []
         }
       ];
 
@@ -78,7 +62,7 @@ describe('serviceUtils', () => {
   });
 
   describe('getServicesForSelect', () => {
-    test('Should return select items for services where some of the onboarding roles have "private-beta"', async () => {
+    test('Should return select items for services with onboarding roles', async () => {
       const testServices: Service[] = [
         {
           label: service1,
@@ -89,48 +73,51 @@ describe('serviceUtils', () => {
           label: service2,
           description: service2,
           onboardingRoles: [
-            otherRole1,
-            privateBetaRole
+            role1
           ]
         },
         {
           label: service3,
           description: service3,
           onboardingRoles: [
-            otherRole1
+            role2
           ]
         },
         {
           label: service4,
           description: service4,
-          onboardingRoles: [
-            otherRole2
-          ]
+          onboardingRoles: []
         },
         {
           label: service5,
           description: service5,
           onboardingRoles: [
-            privateBetaRole
+            role1,
+            role2
           ]
         }
       ];
 
       const results = getServicesForSelect(testServices);
-      expect(results).toHaveLength(2);
+      expect(results).toHaveLength(3);
       expect(results[0]).toStrictEqual({
         value: service2,
         text: service2,
         selected: false
       });
       expect(results[1]).toStrictEqual({
+        value: service3,
+        text: service3,
+        selected: false
+      });
+      expect(results[2]).toStrictEqual({
         value: service5,
         text: service5,
         selected: false
       });
     });
 
-    test('Should return empty array when no service has onboarding roles of "private-beta"', async () => {
+    test('Should return empty array when no service has onboarding roles', async () => {
       const testServices: Service[] = [
         {
           label: service1,
@@ -140,17 +127,12 @@ describe('serviceUtils', () => {
         {
           label: service2,
           description: service2,
-          onboardingRoles: [
-            otherRole1,
-            otherRole2
-          ]
+          onboardingRoles: []
         },
         {
           label: service3,
           description: service3,
-          onboardingRoles: [
-            otherRole1
-          ]
+          onboardingRoles: []
         }
       ];
 


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/SIDM-6594

### Change description ###

- Allow registering of onboarding users without 'private-beta' in onboarding roles
- Convert onboarding role IDs to role names before registering the users

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
