### PR TITLE
Added 500 user limit warning and fixed incorrect string

### DIFF
--- a/src/main/views/generate-report.njk
+++ b/src/main/views/generate-report.njk
@@ -46,7 +46,7 @@
       </form>
 
       {{ govukWarningText({
-        text: 'Generating the report can take some time, please do not refresh the page.',
+        text: "Generating the report can take some time, please do not refresh the page. Generated reports are currently limited to 500 user's details per report for performance reasons.",
         iconFallbackText: "Warning"
       }) }}
     </div>

--- a/src/main/views/view-report.njk
+++ b/src/main/views/view-report.njk
@@ -19,7 +19,7 @@
   {{ super() }}
   {{ breadcrumb([
     ['Generate report', urls.GENERATE_REPORT_URL],
-    ['ReportsHandler']
+    ['Report details']
   ]) }}
 {% endblock %}
 


### PR DESCRIPTION
### Change description ###

- Added warning about 500 user limit on generated reports
- Fixed incorrect breadcrumb string

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
