### PR TITLE
SIDM-7934 - Removed multiple H1 on generate report page

### DIFF
--- a/src/main/views/generate-report.njk
+++ b/src/main/views/generate-report.njk
@@ -28,8 +28,7 @@
         {{ govukInput({
           label: {
             text: "What roles should the report be based on?",
-            classes: "govuk-label govuk-label--m",
-            isPageHeading: true
+            classes: "govuk-label govuk-label--m"
           },
           hint: {
             text: "Please enter the role(s) you want to search for (comma-separated). The results will show all users that have the entered role(s) assigned to them. Archived users are not listed."


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/SIDM-7934

### Change description ###

- Removed secondary H1 on generate report page

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
