### PR TITLE
Disabled using redis in PR/preview

### DIFF
--- a/charts/idam-user-dashboard/values.preview.template.yaml
+++ b/charts/idam-user-dashboard/values.preview.template.yaml
@@ -4,12 +4,6 @@ nodejs:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
   keyVaults:
-    idam-idam-preview:
-      excludeEnvironmentSuffix: true
-      secrets:
-        - redis-hostname
-        - redis-port
-        - redis-key
     idam-idam:
       secrets:
         - AppInsightsInstrumentationKey

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -15,6 +15,7 @@ services:
     scope: 'openid profile roles manage-user search-user'
     responseType: 'code'
 session:
+  secret: 'local'
   redis:
     host: REDIS_HOST
     port: REDIS_PORT

--- a/src/main/modules/properties-volume/index.ts
+++ b/src/main/modules/properties-volume/index.ts
@@ -17,15 +17,6 @@ export class PropertiesVolume {
       this.setSecret('secrets.idam-idam.redis-hostname', 'session.redis.host');
       this.setSecret('secrets.idam-idam.redis-port', 'session.redis.port');
       this.setSecret('secrets.idam-idam.redis-key', 'session.redis.key');
-
-      // Use idam-preview redis if using idam-idam-preview kv
-      if(config.has('secrets.idam-idam-preview')) {
-        console.log('Using idam-preview redis');
-        this.setSecret('secrets.idam-idam-preview.redis-hostname', 'session.redis.host');
-        this.setSecret('secrets.idam-idam-preview.redis-port', 'session.redis.port');
-        this.setSecret('secrets.idam-idam-preview.redis-key', 'session.redis.key');
-      }
-
       this.setSecret('session.redis.key', 'session.secret');
     } else {
       this.setLocalSecret('AppInsightsInstrumentationKey', 'appInsights.instrumentationKey');


### PR DESCRIPTION
### Change description ###

- Disabled using Redis in PR/preview environment, using filestore for sessions instead

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
