### PR TITLE
Fix for AuthorizedAxios appending authentication header to /o/token calls

### DIFF
--- a/src/main/app/authorized-axios/AuthorizedAxios.ts
+++ b/src/main/app/authorized-axios/AuthorizedAxios.ts
@@ -104,9 +104,9 @@ export class AuthorizedAxios extends Axios {
 
   private requestInterceptor = () => {
     this.interceptors.request.use(config => {
-      if (this.oauth.token && config.url !== '/o/token') {
+      if (!config.url?.endsWith('/o/token')) {
         config.headers = config.headers ?? {};
-        config.headers.Authorization = 'Bearer ' + this.oauth.token.raw;
+        config.headers.Authorization = 'Bearer ' + this.oauth?.token?.raw;
       }
 
       return config;


### PR DESCRIPTION
### Change description ###

- Fixes issue where AuthorizedAxios was checking if url was `/o/token` rather than if the url ENDS with `/o/token`, causing it to add authentication header to subsequent token calls

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
