### PR TITLE
Add open in new page button

### DIFF
--- a/src/main/controllers/UserResultsController.ts
+++ b/src/main/controllers/UserResultsController.ts
@@ -82,8 +82,10 @@ export class UserResultsController extends RootController {
       notificationBannerMessage = 'Please check with the eJudiciary support team to see if there are related accounts.';
     }
     if (user.stale) {
-      notificationBannerMessage = notificationBannerMessage?.trim() !== '' ? notificationBannerMessage + '\n' : notificationBannerMessage;
-      notificationBannerMessage = notificationBannerMessage + 'Archived accounts are read only.';
+      if (notificationBannerMessage) {
+        notificationBannerMessage = notificationBannerMessage?.trim() !== '' ? notificationBannerMessage + '\n' : notificationBannerMessage;
+      }
+      notificationBannerMessage = notificationBannerMessage? notificationBannerMessage + 'Archived accounts are read only.' : 'Archived accounts are read only.';
     }
     return notificationBannerMessage;
   }

--- a/src/main/views/user-details.njk
+++ b/src/main/views/user-details.njk
@@ -164,6 +164,16 @@
     ]
   }) }}
 
+  <a id="openInNewTab" href="#" target="_blank" class="govuk-link" rel="noopener noreferrer">Open this in a new tab</a>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const currentURL = window.location.href;
+      const openInNewTabLink = document.getElementById('openInNewTab');
+      openInNewTabLink.href = currentURL;
+    });
+  </script>
+
   <form method="POST" action="{{ urls.USER_ACTIONS_URL }}">
     {{ csrfProtection(csrfToken) }}
     <input type="hidden" name="_userId" value="{{ content.user.id }}">

--- a/src/main/views/view-report.njk
+++ b/src/main/views/view-report.njk
@@ -71,10 +71,7 @@
         {% endset %}
 
         {% set accountViewHTML %}
-          <form method="POST" action="{{ urls.USER_DETAILS_URL | replace(":userUUID", content.user.id) }}">
-            {{ csrfProtection(csrfToken) }}
-            <button type="submit" class="govuk-link">View user</button>
-          </form>
+          <a href="{{ urls.USER_DETAILS_URL | replace(":userUUID", user.id) }}" class="govuk-link" rel="noreferrer noopener" target="_blank">View user</a>
         {% endset %}
 
         {% set users = (users.push(


### PR DESCRIPTION
GDS removed the standard Open in new tab Icon. They said that words where more effective.
Also all the nunjucks components are forcing display:block; so this was the best I could do. It's honestly ugly everywhere.

![image](https://github.com/hmcts/idam-user-dashboard/assets/47384516/d081afb8-9770-438f-90bf-e89c039ef17b)