### PR TITLE
SIDM-9354 remove redundant tokens from oidc middleware

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,7 +25,7 @@ services:
     clientSecret: 'idam_user_dashboard_secret'
     callbackURL: 'http://localhost:3100/oauth2/callback'
     scope: 'openid profile roles manage-user search-user create-user view-user'
-    backendServiceScope: 'create-invitation view-service-provider delete-user view-role manage-user search-user'
+    backendServiceScope: 'create-invitation view-service-provider delete-user view-role manage-user search-user view-user'
     responseType: 'code'
     appointmentMap: '{ "@eJudiciary.net" : "APPOINT" }'
 session:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,7 +25,7 @@ services:
     clientSecret: 'idam_user_dashboard_secret'
     callbackURL: 'http://localhost:3100/oauth2/callback'
     scope: 'openid profile roles manage-user search-user create-user view-user'
-    backendServiceScope: 'create-invitation view-service-provider delete-user'
+    backendServiceScope: 'create-invitation view-service-provider delete-user view-role manage-user search-user'
     responseType: 'code'
     appointmentMap: '{ "@eJudiciary.net" : "APPOINT" }'
 session:

--- a/src/main/app/idam-api/IdamAPI.ts
+++ b/src/main/app/idam-api/IdamAPI.ts
@@ -1,7 +1,6 @@
 import { AxiosInstance } from 'axios';
 import { User } from '../../interfaces/User';
 import { TelemetryClient } from 'applicationinsights';
-import { Role } from '../../interfaces/Role';
 import { V2Role } from '../../interfaces/V2Role';
 import { HTTPError } from '../errors/HttpError';
 import { constants as http } from 'http2';
@@ -16,7 +15,6 @@ const {Logger} = require('@hmcts/nodejs-logging');
 export class IdamAPI {
   constructor(
     private readonly userAxios: AxiosInstance,
-    private readonly systemAxios: AxiosInstance,
     private readonly idamApiAxios: AxiosInstance,
     private readonly logger : typeof Logger,
     private readonly telemetryClient: TelemetryClient
@@ -121,18 +119,6 @@ export class IdamAPI {
         this.telemetryClient.trackTrace({message: errorMessage});
         this.logger.error(`${error.stack || error}`);
         return Promise.reject(errorMessage);
-      });
-  }
-
-  public getAllRoles(): Promise<Role[]> {
-    return this.systemAxios
-      .get('/roles/')
-      .then(results => results.data)
-      .catch(error => {
-        const errorMessage = 'Error retrieving all roles from IDAM API';
-        this.telemetryClient.trackTrace({message: errorMessage});
-        this.logger.error(`${error.stack || error}`);
-        throw new HTTPError(http.HTTP_STATUS_INTERNAL_SERVER_ERROR);
       });
   }
 

--- a/src/main/app/idam-api/IdamAPI.ts
+++ b/src/main/app/idam-api/IdamAPI.ts
@@ -16,7 +16,6 @@ export class IdamAPI {
   constructor(
     private readonly userAxios: AxiosInstance,
     private readonly systemAxios: AxiosInstance,
-    private readonly clientAxios: AxiosInstance,
     private readonly idamApiAxios: AxiosInstance,
     private readonly logger : typeof Logger,
     private readonly telemetryClient: TelemetryClient
@@ -55,7 +54,7 @@ export class IdamAPI {
   }
 
   public getUserV2ById(id: string): Promise<V2User> {
-    return this.clientAxios
+    return this.idamApiAxios
       .get('/api/v2/users/' + id)
       .then(results => results.data)
       .catch(error => {

--- a/src/main/app/idam-api/IdamAPI.ts
+++ b/src/main/app/idam-api/IdamAPI.ts
@@ -2,6 +2,7 @@ import { AxiosInstance } from 'axios';
 import { User } from '../../interfaces/User';
 import { TelemetryClient } from 'applicationinsights';
 import { Role } from '../../interfaces/Role';
+import { V2Role } from '../../interfaces/V2Role';
 import { HTTPError } from '../errors/HttpError';
 import { constants as http } from 'http2';
 import { UserRegistrationDetails } from '../../interfaces/UserRegistrationDetails';
@@ -135,8 +136,20 @@ export class IdamAPI {
       });
   }
 
+  public getAllV2Roles(): Promise<V2Role[]> {
+    return this.idamApiAxios
+      .get('/api/v2/roles')
+      .then(results => results.data)
+      .catch(error => {
+        const errorMessage = 'Error retrieving all v2 roles from IDAM API';
+        this.telemetryClient.trackTrace({message: errorMessage});
+        this.logger.error(`${error.stack || error}`);
+        throw new HTTPError(http.HTTP_STATUS_INTERNAL_SERVER_ERROR);
+      });
+  }
+
   public async getAssignableRoles(roleNames: string[]) {
-    const allRoles = await this.getAllRoles();
+    const allRoles = await this.getAllV2Roles();
     const rolesMap = new Map(allRoles
       .filter(role => role !== undefined)
       .map(role => [role.id, role])
@@ -145,8 +158,8 @@ export class IdamAPI {
     const collection: Set<string> = new Set();
     Array.from(rolesMap.values())
       .filter(role => roleNames.includes(role.name))
-      .filter(role => Array.isArray(role.assignableRoles))
-      .forEach(role => role.assignableRoles
+      .filter(role => Array.isArray(role.assignableRoleNames))
+      .forEach(role => role.assignableRoleNames
         .filter(r => rolesMap.has(r))
         .forEach(r => collection.add(rolesMap.get(r).name))
       );

--- a/src/main/controllers/AddPrivateBetaServiceController.ts
+++ b/src/main/controllers/AddPrivateBetaServiceController.ts
@@ -8,7 +8,7 @@ import { MISSING_PRIVATE_BETA_SERVICE_ERROR } from '../utils/error';
 import { getServicesForSelect } from '../utils/serviceUtils';
 import { UserType } from '../utils/UserType';
 import { Service } from '../interfaces/Service';
-import { Role } from '../interfaces/Role';
+import { V2Role } from '../interfaces/V2Role';
 import { InviteService } from '../app/invite-service/InviteService';
 
 @autobind
@@ -72,8 +72,8 @@ export class AddPrivateBetaServiceController extends RootController {
     return rolesToAdd;
   }
 
-  private async getRolesMap(req: AuthedRequest): Promise<Map<string, Role>> {
-    const allRoles = await req.scope.cradle.api.getAllRoles();
+  private async getRolesMap(req: AuthedRequest): Promise<Map<string, V2Role>> {
+    const allRoles = await req.scope.cradle.api.getAllV2Roles();
     const rolesMap = new Map(allRoles
       .filter(role => role !== undefined)
       .map(role => [role.id, role])

--- a/src/main/controllers/AddUserDetailsController.ts
+++ b/src/main/controllers/AddUserDetailsController.ts
@@ -16,7 +16,7 @@ import { PageError } from '../interfaces/PageData';
 import { constructAllRoleAssignments } from '../utils/roleUtils';
 import { UserType } from '../utils/UserType';
 import { getServicesForSelect, hasPrivateBetaServices } from '../utils/serviceUtils';
-import { Role } from '../interfaces/Role';
+import { V2Role } from '../interfaces/V2Role';
 
 export const ROLE_HINT_WITH_PRIVATE_BETA = 'Private Beta Citizen is a citizen who is trialling a new function. Professional is an external professional e.g. a caseworker. Support is an internal employee e.g. CFT Level 2 Support.';
 export const ROLE_HINT_WITHOUT_PRIVATE_BETA = 'Professional is an external professional e.g. a caseworker. Support is an internal employee e.g. CFT Level 2 Support.';
@@ -87,7 +87,7 @@ export class AddUserDetailsController extends RootController {
         selectedService: ''
       }});
     } else {
-      const allRoles = await req.scope.cradle.api.getAllRoles();
+      const allRoles = await req.scope.cradle.api.getAllV2Roles();
       const roleAssignment = constructAllRoleAssignments(allRoles, req.idam_user_dashboard_session.user.assignableRoles);
       return super.post(req, res, 'add-user-roles', { content: { user: user, roles: roleAssignment } });
     }
@@ -121,8 +121,8 @@ export class AddUserDetailsController extends RootController {
     return hasProperty(fields, 'userType') ? fields.userType : '';
   }
 
-  private async getRolesMap(req: AuthedRequest): Promise<Map<string, Role>> {
-    const allRoles = await req.scope.cradle.api.getAllRoles();
+  private async getRolesMap(req: AuthedRequest): Promise<Map<string, V2Role>> {
+    const allRoles = await req.scope.cradle.api.getAllV2Roles();
     const rolesMap = new Map(allRoles
       .filter(role => role !== undefined)
       .map(role => [role.id, role])

--- a/src/main/controllers/AddUserRolesController.ts
+++ b/src/main/controllers/AddUserRolesController.ts
@@ -26,7 +26,7 @@ export class AddUserRolesController extends RootController {
     const fields = req.body;
 
     if (!hasProperty(req.body, 'roles')) {
-      const allRoles = await req.scope.cradle.api.getAllRoles();
+      const allRoles = await req.scope.cradle.api.getAllV2Roles();
       const roleAssignment = constructAllRoleAssignments(allRoles, req.idam_user_dashboard_session.user.assignableRoles);
 
       const user = {

--- a/src/main/interfaces/Role.ts
+++ b/src/main/interfaces/Role.ts
@@ -1,8 +1,0 @@
-export interface Role {
-  id: string;
-  name: string;
-  description: string;
-  assignableRoles: string[];
-  conflictingRoles: string[];
-  assigned: boolean;
-}

--- a/src/main/interfaces/V2Role.ts
+++ b/src/main/interfaces/V2Role.ts
@@ -1,0 +1,7 @@
+export interface V2Role {
+  id: string;
+  name: string;
+  description: string;
+  assignableRoleNames: string[];
+  assigned: boolean;
+}

--- a/src/main/utils/roleUtils.ts
+++ b/src/main/utils/roleUtils.ts
@@ -1,4 +1,4 @@
-import { Role } from '../interfaces/Role';
+import { V2Role } from '../interfaces/V2Role';
 import { UserRoleAssignment } from '../interfaces/UserRoleAssignment';
 import { V2User } from '../interfaces/V2User';
 import { User } from '../interfaces/User';
@@ -22,30 +22,30 @@ const sortRolesByAssignableAndName = (a: UserRoleAssignment, b: UserRoleAssignme
   return sortRolesByName(a.name.toLowerCase(), b.name.toLowerCase());
 };
 
-export const constructAllRoleAssignments = (allRoles: Role[], assignableRoles: string[]): UserRoleAssignment[] => {
+export const constructAllRoleAssignments = (allRoles: V2Role[], assignedRoleNames: string[]): UserRoleAssignment[] => {
   const userRoleAssignments: UserRoleAssignment[] = [];
   allRoles
     .map(roles => roles.name)
     .forEach(r => {
       const obj = {} as UserRoleAssignment;
       obj.name = r;
-      obj.assignable = assignableRoles.includes(r);
+      obj.assignable = assignedRoleNames.includes(r);
       userRoleAssignments.push(obj);
     });
   userRoleAssignments.sort((a, b) => sortRolesByAssignableAndName(a, b));
   return userRoleAssignments;
 };
 
-export const constructUserRoleAssignments = (assignableRoles: string[], assignedRoles: string[]): UserRoleAssignment[] => {
+export const constructUserRoleAssignments = (assignableRoleNames: string[], assignedRoleNames: string[]): UserRoleAssignment[] => {
   const userRoleAssignments: UserRoleAssignment[] = [];
   const combinedRoles = [];
-  combinedRoles.push(...assignableRoles, ...assignedRoles);
+  combinedRoles.push(...assignableRoleNames, ...assignedRoleNames);
 
   combinedRoles.forEach(r => {
     const obj = {} as UserRoleAssignment;
     obj.name = r;
-    obj.assignable = assignableRoles.includes(r);
-    obj.assigned = assignedRoles.includes(r);
+    obj.assignable = assignableRoleNames.includes(r);
+    obj.assigned = assignedRoleNames.includes(r);
     userRoleAssignments.push(obj);
   });
 
@@ -74,6 +74,6 @@ export const processMfaRole = (user: User) => {
   }
 };
 
-export const rolesExist = (roleIds: string[], rolesMap: Map<string, Role>): boolean => {
+export const rolesExist = (roleIds: string[], rolesMap: Map<string, V2Role>): boolean => {
   return roleIds.every(r => rolesMap.has(r));
 };

--- a/src/main/utils/serviceUtils.ts
+++ b/src/main/utils/serviceUtils.ts
@@ -1,19 +1,19 @@
 import { SelectItem } from '../interfaces/SelectItem';
 import { Service } from '../interfaces/Service';
-import { Role } from '../interfaces/Role';
+import { V2Role } from '../interfaces/V2Role';
 import { rolesExist } from './roleUtils';
 
-const getServicesWithPrivateBetaRole = (services: Service[], rolesMap: Map<string, Role>): Service[] => {
+const getServicesWithPrivateBetaRole = (services: Service[], rolesMap: Map<string, V2Role>): Service[] => {
   return services
     .filter(service => service.onboardingRoles.length > 0)
     .filter(service => rolesExist(service.onboardingRoles, rolesMap));
 };
 
-export const hasPrivateBetaServices = (services: Service[], rolesMap: Map<string, Role>): boolean => {
+export const hasPrivateBetaServices = (services: Service[], rolesMap: Map<string, V2Role>): boolean => {
   return services.some(service => service.onboardingRoles.length > 0 && rolesExist(service.onboardingRoles, rolesMap));
 };
 
-export const getServicesForSelect = (services: Service[], rolesMap: Map<string, Role>): SelectItem[] => {
+export const getServicesForSelect = (services: Service[], rolesMap: Map<string, V2Role>): SelectItem[] => {
   const privateBetaServices = getServicesWithPrivateBetaRole(services, rolesMap)
     .sort((a: Service, b: Service) => a.label.toLowerCase() > b.label.toLowerCase() ? 1 : -1);
   return privateBetaServices.map((service) => ({ value: service.label, text: service.label, selected: false }));

--- a/src/test/unit/test/app/idam-api/IdamAPI.ts
+++ b/src/test/unit/test/app/idam-api/IdamAPI.ts
@@ -32,7 +32,7 @@ describe('IdamAPI', () => {
         const mockAxios = {get: async () => results} as any;
         const mockLogger = {};
         const mockTelemetryClient = {} as any;
-        const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+        const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
         await expect(api.searchUsersByEmail(parameter.input)).resolves.toEqual(results.data);
       });
@@ -42,7 +42,7 @@ describe('IdamAPI', () => {
       const mockAxios = { get: async () => { throw new Error ('error'); } } as any;
       const mockLogger = { error: jest.fn() } as any;
       const mockTelemetryClient = { trackTrace: jest.fn() } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.searchUsersByEmail('')).rejects.toEqual('Error retrieving user by email from IDAM API');
     });
@@ -64,7 +64,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.searchUsersBySsoId(testSsoId)).resolves.toEqual(results.data);
     });
@@ -79,7 +79,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.searchUsersBySsoId('')).rejects.toEqual('Error retrieving user by ssoId from IDAM API');
     });
@@ -101,7 +101,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getUserById(testUserId)).resolves.toEqual(results.data);
     });
@@ -116,48 +116,48 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getUserById('')).rejects.toEqual('Error retrieving user by ID from IDAM API');
     });
   });
 
-  describe('getAllRoles', () => {
+  describe('getAllV2Roles', () => {
     test('Should return all users', () => {
       const results = {
         data: [
           {
             id: '1',
             name: 'test-role-1',
-            assignableRoles: ['test-role-1', 'test-role-2']
+            assignableRoleNames: ['test-role-1', 'test-role-2']
           },
           {
             id: '2',
             name: 'test-role-2',
-            assignableRoles: ['test-role-2']
+            assignableRoleNames: ['test-role-2']
           },
           {
             id: '3',
             name: 'test-role-3',
-            assignableRoles: ['test-role-3', 'test-role-1']
+            assignableRoleNames: ['test-role-3', 'test-role-1']
           }
         ]
       };
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
-      expect(api.getAllRoles()).resolves.toEqual(results.data);
+      expect(api.getAllV2Roles()).resolves.toEqual(results.data);
     });
 
     test('Should return error if API issue', async () => {
       const mockAxios = {get: () => Promise.reject('')} as any;
       const mockLogger = {error: jest.fn()} as any;
       const mockTelemetryClient = {trackTrace: jest.fn()} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
-      await expect(api.getAllRoles()).rejects.toThrowError();
+      await expect(api.getAllV2Roles()).rejects.toThrowError();
       expect(mockLogger.error).toBeCalled();
     });
   });
@@ -175,7 +175,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
       api.getAllV2Roles = jest.fn();
 
       when(api.getAllV2Roles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as V2Role[]));
@@ -200,7 +200,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
       api.getAllV2Roles = jest.fn();
 
       when(api.getAllV2Roles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as V2Role[]));
@@ -218,7 +218,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
       api.getAllV2Roles = jest.fn();
 
       when(api.getAllV2Roles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as V2Role[]));
@@ -237,7 +237,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => jest.fn()} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
       api.getAllV2Roles = jest.fn();
 
       when(api.getAllV2Roles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as V2Role[]));
@@ -265,7 +265,7 @@ describe('IdamAPI', () => {
       const mockAxios = {patch: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.editUserById(testUserId, fields)).resolves.toEqual(results.data);
     });
@@ -284,7 +284,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.editUserById(testUserId, fields)).rejects.toEqual('Error patching user details in IDAM API');
     });
@@ -295,7 +295,7 @@ describe('IdamAPI', () => {
       const mockAxios = {delete: jest.fn().mockReturnValue(Promise.resolve())} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       await expect(api.deleteUserById(testUserId)).resolves.not.toThrow();
       expect(mockAxios.delete).toBeCalledWith('/api/v2/users/12345');
@@ -305,7 +305,7 @@ describe('IdamAPI', () => {
       const mockAxios = {delete: jest.fn().mockReturnValue(Promise.reject('Delete failed'))} as any;
       const mockLogger = {error: jest.fn()} as any;
       const mockTelemetryClient = {trackTrace: jest.fn()} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       await expect(api.deleteUserById('-1')).rejects.toThrowError('Error deleting user by ID from IDAM API');
       expect(mockAxios.delete).toBeCalledWith('/api/v2/users/-1');
@@ -327,7 +327,7 @@ describe('IdamAPI', () => {
       const mockAxios = {post: async () => Promise.resolve(result)} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.registerUser(input)).resolves.toEqual(testValue);
     });
@@ -340,7 +340,7 @@ describe('IdamAPI', () => {
       const mockTelemetryClient = {
         trackTrace: jest.fn()
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.registerUser(input)).rejects.toEqual('Error register new user in IDAM API');
     });
@@ -364,7 +364,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getAllServices()).resolves.toEqual(results.data);
     });
@@ -379,7 +379,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getAllServices()).rejects.toEqual('Error retrieving all services from IDAM API');
     });
@@ -401,7 +401,7 @@ describe('IdamAPI', () => {
       const mockAxios = {post: async () => Promise.resolve(result)} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.grantRolesToUser(testUserId, roleDefinitions)).resolves.toEqual(testValue);
     });
@@ -416,7 +416,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.grantRolesToUser(testUserId, roleDefinitions)).rejects.toEqual('Error granting user roles in IDAM API');
     });
@@ -429,7 +429,7 @@ describe('IdamAPI', () => {
       const mockAxios = {delete: async () => Promise.resolve(result)} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.removeRoleFromUser(testUserId, 'role1')).resolves.toEqual(testValue);
     });
@@ -444,7 +444,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.removeRoleFromUser(testUserId, 'role1')).rejects.toEqual('Error deleting user role in IDAM API');
     });
@@ -476,7 +476,7 @@ describe('IdamAPI', () => {
       const mockAxios: any = { get: jest.fn().mockResolvedValue(results) };
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getUsersWithRoles(roles)).resolves.toEqual(results.data);
       expect(mockAxios.get).toBeCalledWith(expectedAxiosCall, {'timeout': 20000});
@@ -507,7 +507,7 @@ describe('IdamAPI', () => {
       const mockAxios: any = { get: jest.fn().mockResolvedValue(results) };
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getUsersWithRoles(roles)).resolves.toEqual(results.data);
       expect(mockAxios.get).toBeCalledWith(expectedAxiosCall, {'timeout': 20000});
@@ -519,7 +519,7 @@ describe('IdamAPI', () => {
       const mockAxios: any = {get: jest.fn().mockRejectedValue('')};
       const mockLogger = {error: jest.fn()} as any;
       const mockTelemetryClient = {trackTrace: jest.fn()} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       await expect(api.getUsersWithRoles(roles)).rejects.toThrowError();
       expect(mockLogger.error).toBeCalled();

--- a/src/test/unit/test/app/idam-api/IdamAPI.ts
+++ b/src/test/unit/test/app/idam-api/IdamAPI.ts
@@ -1,6 +1,5 @@
 import { IdamAPI } from '../../../../../main/app/idam-api/IdamAPI';
 import {SearchType} from '../../../../../main/utils/SearchType';
-import { Role } from '../../../../../main/interfaces/Role';
 import { V2Role } from '../../../../../main/interfaces/V2Role';
 import { when } from 'jest-when';
 
@@ -231,7 +230,7 @@ describe('IdamAPI', () => {
         { id: '1', name: 'test-role-1', assignableRoleNames: ['1', '2'] },
         { id: '2', name: 'test-role-2', assignableRoleNames: [] },
         { id: '3', name: 'test-role-3' },
-        undefined as unknown as Role
+        undefined as unknown as V2Role
       ];
 
       const mockAxios = {get: async () => jest.fn()} as any;

--- a/src/test/unit/test/app/idam-api/IdamAPI.ts
+++ b/src/test/unit/test/app/idam-api/IdamAPI.ts
@@ -1,6 +1,7 @@
 import { IdamAPI } from '../../../../../main/app/idam-api/IdamAPI';
 import {SearchType} from '../../../../../main/utils/SearchType';
 import { Role } from '../../../../../main/interfaces/Role';
+import { V2Role } from '../../../../../main/interfaces/V2Role';
 import { when } from 'jest-when';
 
 describe('IdamAPI', () => {
@@ -163,11 +164,11 @@ describe('IdamAPI', () => {
 
   describe('getAssignableRoles', () => {
     test('Should return all the assignable roles for a role', () => {
-      const getAllRolesMockResponse: Partial<Role>[] = [
-        { id: '1', name: 'test-role-1', assignableRoles: ['1', '2'] },
-        { id: '2', name: 'test-role-2', assignableRoles: ['2'] },
-        { id: '3', name: 'test-role-3', assignableRoles: ['3', '1'] },
-        { id: '4', name: 'test-role-4', assignableRoles: ['4', '1'] }
+      const getAllRolesMockResponse: Partial<V2Role>[] = [
+        { id: '1', name: 'test-role-1', assignableRoleNames: ['1', '2'] },
+        { id: '2', name: 'test-role-2', assignableRoleNames: ['2'] },
+        { id: '3', name: 'test-role-3', assignableRoleNames: ['3', '1'] },
+        { id: '4', name: 'test-role-4', assignableRoleNames: ['4', '1'] }
       ];
       const results = ['test-role-3', 'test-role-1'];
 
@@ -175,24 +176,24 @@ describe('IdamAPI', () => {
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
       const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
-      api.getAllRoles = jest.fn();
+      api.getAllV2Roles = jest.fn();
 
-      when(api.getAllRoles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as Role[]));
+      when(api.getAllV2Roles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as V2Role[]));
       expect(api.getAssignableRoles(['test-role-3'])).resolves.toEqual(results);
-      expect(api.getAllRoles).toBeCalledTimes(1);
+      expect(api.getAllV2Roles).toBeCalledTimes(1);
     });
 
     test('Should return all the assignable roles for a set of roles', () => {
-      const getAllRolesMockResponse: Partial<Role>[] = [
-        { id: '1', name: 'test-role-1', assignableRoles: ['1', '2'] },
-        { id: '2', name: 'test-role-2', assignableRoles: ['2'] },
-        { id: '3', name: 'test-role-3', assignableRoles: ['3', '1'] },
-        { id: '4', name: 'test-role-4', assignableRoles: ['4', '1'] },
-        { id: '5', name: 'test-role-5', assignableRoles: ['5'] },
-        { id: '6', name: 'test-role-6', assignableRoles: ['6', '2', '5'] },
-        { id: '7', name: 'test-role-7', assignableRoles: ['7'] },
-        { id: '8', name: 'test-role-8', assignableRoles: ['9'] },
-        { id: '9', name: 'test-role-9', assignableRoles: [] }
+      const getAllRolesMockResponse: Partial<V2Role>[] = [
+        { id: '1', name: 'test-role-1', assignableRoleNames: ['1', '2'] },
+        { id: '2', name: 'test-role-2', assignableRoleNames: ['2'] },
+        { id: '3', name: 'test-role-3', assignableRoleNames: ['3', '1'] },
+        { id: '4', name: 'test-role-4', assignableRoleNames: ['4', '1'] },
+        { id: '5', name: 'test-role-5', assignableRoleNames: ['5'] },
+        { id: '6', name: 'test-role-6', assignableRoleNames: ['6', '2', '5'] },
+        { id: '7', name: 'test-role-7', assignableRoleNames: ['7'] },
+        { id: '8', name: 'test-role-8', assignableRoleNames: ['9'] },
+        { id: '9', name: 'test-role-9', assignableRoleNames: [] }
       ];
       const results = ['test-role-3', 'test-role-1', 'test-role-6', 'test-role-2', 'test-role-5', 'test-role-9'];
 
@@ -200,17 +201,17 @@ describe('IdamAPI', () => {
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
       const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
-      api.getAllRoles = jest.fn();
+      api.getAllV2Roles = jest.fn();
 
-      when(api.getAllRoles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as Role[]));
+      when(api.getAllV2Roles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as V2Role[]));
       expect(api.getAssignableRoles(['test-role-3', 'test-role-6', 'test-role-8'])).resolves.toEqual(results);
-      expect(api.getAllRoles).toBeCalledTimes(1);
+      expect(api.getAllV2Roles).toBeCalledTimes(1);
     });
 
     test('Should return only itself as assignable role if no other assignable roles', () => {
-      const getAllRolesMockResponse: Partial<Role>[] = [
-        { id: '1', name: 'test-role-1', assignableRoles: ['1', '2'] },
-        { id: '2', name: 'test-role-2', assignableRoles: ['2'] },
+      const getAllRolesMockResponse: Partial<V2Role>[] = [
+        { id: '1', name: 'test-role-1', assignableRoleNames: ['1', '2'] },
+        { id: '2', name: 'test-role-2', assignableRoleNames: ['2'] },
       ];
       const results = ['test-role-2'];
 
@@ -218,17 +219,17 @@ describe('IdamAPI', () => {
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
       const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
-      api.getAllRoles = jest.fn();
+      api.getAllV2Roles = jest.fn();
 
-      when(api.getAllRoles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as Role[]));
+      when(api.getAllV2Roles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as V2Role[]));
       expect(api.getAssignableRoles(['test-role-2'])).resolves.toEqual(results);
-      expect(api.getAllRoles).toBeCalledTimes(1);
+      expect(api.getAllV2Roles).toBeCalledTimes(1);
     });
 
     test('Should return empty if no assignable roles or role undefined', () => {
-      const getAllRolesMockResponse: Partial<Role>[] = [
-        { id: '1', name: 'test-role-1', assignableRoles: ['1', '2'] },
-        { id: '2', name: 'test-role-2', assignableRoles: [] },
+      const getAllRolesMockResponse: Partial<V2Role>[] = [
+        { id: '1', name: 'test-role-1', assignableRoleNames: ['1', '2'] },
+        { id: '2', name: 'test-role-2', assignableRoleNames: [] },
         { id: '3', name: 'test-role-3' },
         undefined as unknown as Role
       ];
@@ -237,11 +238,11 @@ describe('IdamAPI', () => {
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
       const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
-      api.getAllRoles = jest.fn();
+      api.getAllV2Roles = jest.fn();
 
-      when(api.getAllRoles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as Role[]));
+      when(api.getAllV2Roles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as V2Role[]));
       expect(api.getAssignableRoles(['test-role-2', 'test-role-3'])).resolves.toEqual([]);
-      expect(api.getAllRoles).toBeCalledTimes(1);
+      expect(api.getAllV2Roles).toBeCalledTimes(1);
     });
   });
 

--- a/src/test/unit/test/app/idam-api/IdamAPI.ts
+++ b/src/test/unit/test/app/idam-api/IdamAPI.ts
@@ -31,7 +31,7 @@ describe('IdamAPI', () => {
         const mockAxios = {get: async () => results} as any;
         const mockLogger = {};
         const mockTelemetryClient = {} as any;
-        const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+        const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
         await expect(api.searchUsersByEmail(parameter.input)).resolves.toEqual(results.data);
       });
@@ -41,7 +41,7 @@ describe('IdamAPI', () => {
       const mockAxios = { get: async () => { throw new Error ('error'); } } as any;
       const mockLogger = { error: jest.fn() } as any;
       const mockTelemetryClient = { trackTrace: jest.fn() } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.searchUsersByEmail('')).rejects.toEqual('Error retrieving user by email from IDAM API');
     });
@@ -63,7 +63,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.searchUsersBySsoId(testSsoId)).resolves.toEqual(results.data);
     });
@@ -78,7 +78,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.searchUsersBySsoId('')).rejects.toEqual('Error retrieving user by ssoId from IDAM API');
     });
@@ -100,7 +100,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getUserById(testUserId)).resolves.toEqual(results.data);
     });
@@ -115,7 +115,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getUserById('')).rejects.toEqual('Error retrieving user by ID from IDAM API');
     });
@@ -145,7 +145,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getAllRoles()).resolves.toEqual(results.data);
     });
@@ -154,7 +154,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: () => Promise.reject('')} as any;
       const mockLogger = {error: jest.fn()} as any;
       const mockTelemetryClient = {trackTrace: jest.fn()} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       await expect(api.getAllRoles()).rejects.toThrowError();
       expect(mockLogger.error).toBeCalled();
@@ -174,7 +174,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
       api.getAllRoles = jest.fn();
 
       when(api.getAllRoles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as Role[]));
@@ -199,7 +199,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
       api.getAllRoles = jest.fn();
 
       when(api.getAllRoles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as Role[]));
@@ -217,7 +217,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
       api.getAllRoles = jest.fn();
 
       when(api.getAllRoles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as Role[]));
@@ -236,7 +236,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => jest.fn()} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
       api.getAllRoles = jest.fn();
 
       when(api.getAllRoles).mockReturnValue(Promise.resolve(getAllRolesMockResponse as Role[]));
@@ -264,7 +264,7 @@ describe('IdamAPI', () => {
       const mockAxios = {patch: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.editUserById(testUserId, fields)).resolves.toEqual(results.data);
     });
@@ -283,7 +283,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.editUserById(testUserId, fields)).rejects.toEqual('Error patching user details in IDAM API');
     });
@@ -294,7 +294,7 @@ describe('IdamAPI', () => {
       const mockAxios = {delete: jest.fn().mockReturnValue(Promise.resolve())} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       await expect(api.deleteUserById(testUserId)).resolves.not.toThrow();
       expect(mockAxios.delete).toBeCalledWith('/api/v2/users/12345');
@@ -304,7 +304,7 @@ describe('IdamAPI', () => {
       const mockAxios = {delete: jest.fn().mockReturnValue(Promise.reject('Delete failed'))} as any;
       const mockLogger = {error: jest.fn()} as any;
       const mockTelemetryClient = {trackTrace: jest.fn()} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       await expect(api.deleteUserById('-1')).rejects.toThrowError('Error deleting user by ID from IDAM API');
       expect(mockAxios.delete).toBeCalledWith('/api/v2/users/-1');
@@ -326,7 +326,7 @@ describe('IdamAPI', () => {
       const mockAxios = {post: async () => Promise.resolve(result)} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.registerUser(input)).resolves.toEqual(testValue);
     });
@@ -339,7 +339,7 @@ describe('IdamAPI', () => {
       const mockTelemetryClient = {
         trackTrace: jest.fn()
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.registerUser(input)).rejects.toEqual('Error register new user in IDAM API');
     });
@@ -363,7 +363,7 @@ describe('IdamAPI', () => {
       const mockAxios = {get: async () => results} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getAllServices()).resolves.toEqual(results.data);
     });
@@ -378,7 +378,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getAllServices()).rejects.toEqual('Error retrieving all services from IDAM API');
     });
@@ -400,7 +400,7 @@ describe('IdamAPI', () => {
       const mockAxios = {post: async () => Promise.resolve(result)} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.grantRolesToUser(testUserId, roleDefinitions)).resolves.toEqual(testValue);
     });
@@ -415,7 +415,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.grantRolesToUser(testUserId, roleDefinitions)).rejects.toEqual('Error granting user roles in IDAM API');
     });
@@ -428,7 +428,7 @@ describe('IdamAPI', () => {
       const mockAxios = {delete: async () => Promise.resolve(result)} as any;
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.removeRoleFromUser(testUserId, 'role1')).resolves.toEqual(testValue);
     });
@@ -443,7 +443,7 @@ describe('IdamAPI', () => {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         trackTrace : () => {}
       } as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.removeRoleFromUser(testUserId, 'role1')).rejects.toEqual('Error deleting user role in IDAM API');
     });
@@ -475,7 +475,7 @@ describe('IdamAPI', () => {
       const mockAxios: any = { get: jest.fn().mockResolvedValue(results) };
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getUsersWithRoles(roles)).resolves.toEqual(results.data);
       expect(mockAxios.get).toBeCalledWith(expectedAxiosCall, {'timeout': 20000});
@@ -506,7 +506,7 @@ describe('IdamAPI', () => {
       const mockAxios: any = { get: jest.fn().mockResolvedValue(results) };
       const mockLogger = {} as any;
       const mockTelemetryClient = {} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       expect(api.getUsersWithRoles(roles)).resolves.toEqual(results.data);
       expect(mockAxios.get).toBeCalledWith(expectedAxiosCall, {'timeout': 20000});
@@ -518,7 +518,7 @@ describe('IdamAPI', () => {
       const mockAxios: any = {get: jest.fn().mockRejectedValue('')};
       const mockLogger = {error: jest.fn()} as any;
       const mockTelemetryClient = {trackTrace: jest.fn()} as any;
-      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
+      const api = new IdamAPI(mockAxios, mockAxios, mockAxios, mockLogger, mockTelemetryClient);
 
       await expect(api.getUsersWithRoles(roles)).rejects.toThrowError();
       expect(mockLogger.error).toBeCalled();

--- a/src/test/unit/test/controllers/AddPrivateBetaServiceController.ts
+++ b/src/test/unit/test/controllers/AddPrivateBetaServiceController.ts
@@ -64,7 +64,7 @@ describe('Add private beta service controller', () => {
 
   test('Should render the add user completion page when a service is selected', async () => {
     when(mockApi.getAllServices).calledWith().mockReturnValue(services);
-    when(mockApi.getAllRoles).calledWith().mockReturnValue(allRoles);
+    when(mockApi.getAllV2Roles).calledWith().mockReturnValue(allRoles);
     when(inviteService.inviteUser).mockResolvedValue({} as any);
 
     req.body = {
@@ -85,7 +85,7 @@ describe('Add private beta service controller', () => {
 
   test('Should render the add private beta service page with error when problem occurring during user registration', async () => {
     when(mockApi.getAllServices).calledWith().mockReturnValue(services);
-    when(mockApi.getAllRoles).calledWith().mockReturnValue(allRoles);
+    when(mockApi.getAllV2Roles).calledWith().mockReturnValue(allRoles);
     when(inviteService.inviteUser).mockRejectedValue(error);
 
     req.body = {

--- a/src/test/unit/test/controllers/AddUserDetailsController.ts
+++ b/src/test/unit/test/controllers/AddUserDetailsController.ts
@@ -83,7 +83,7 @@ describe('Add user details controller', () => {
   test('Should render the add user details page when adding a non-existing user\'s email when there is no service with private beta', async () => {
     when(mockApi.searchUsersByEmail).calledWith(email).mockReturnValue([]);
     when(mockApi.getAllServices).calledWith().mockReturnValue(servicesWithoutPrivateBeta);
-    when(mockApi.getAllRoles).calledWith().mockReturnValue(allRoles);
+    when(mockApi.getAllV2Roles).calledWith().mockReturnValue(allRoles);
 
     req.body.email = email;
     req.idam_user_dashboard_session = { user: { assignableRoles: [UserType.Citizen] } };
@@ -97,7 +97,7 @@ describe('Add user details controller', () => {
   test('Should render the add user details page when adding a non-existing user\'s email when there is a service with private beta and the citizen role is assignable', async () => {
     when(mockApi.searchUsersByEmail).calledWith(email).mockReturnValue([]);
     when(mockApi.getAllServices).calledWith().mockReturnValue(servicesWithPrivateBeta);
-    when(mockApi.getAllRoles).calledWith().mockReturnValue(allRoles);
+    when(mockApi.getAllV2Roles).calledWith().mockReturnValue(allRoles);
 
     req.body.email = email;
     req.idam_user_dashboard_session = { user: { assignableRoles: [UserType.Citizen] } };
@@ -111,7 +111,7 @@ describe('Add user details controller', () => {
   test('Should render the add user details page when adding a non-existing user\'s email when there is a service with private beta but the citizen role is not assignable', async () => {
     when(mockApi.searchUsersByEmail).calledWith(email).mockReturnValue([]);
     when(mockApi.getAllServices).calledWith().mockReturnValue(servicesWithPrivateBeta);
-    when(mockApi.getAllRoles).calledWith().mockReturnValue(allRoles);
+    when(mockApi.getAllV2Roles).calledWith().mockReturnValue(allRoles);
 
     req.body.email = email;
     req.idam_user_dashboard_session = { user: { assignableRoles: [] } };
@@ -294,7 +294,7 @@ describe('Add user details controller', () => {
   });
 
   test('Should render the add user completion page when all fields populated', async () => {
-    when(mockApi.getAllRoles).calledWith().mockReturnValue(allRoles);
+    when(mockApi.getAllV2Roles).calledWith().mockReturnValue(allRoles);
 
     req.body._email = email;
     req.body.forename = name;

--- a/src/test/unit/test/controllers/AddUserRolesController.ts
+++ b/src/test/unit/test/controllers/AddUserRolesController.ts
@@ -151,7 +151,7 @@ describe('Add user roles controller', () => {
       }
     ];
 
-    when(mockApi.getAllRoles).calledWith().mockReturnValue(allRoles);
+    when(mockApi.getAllV2Roles).calledWith().mockReturnValue(allRoles);
 
     req.body._email = email;
     req.body._forename = forename;

--- a/src/test/unit/test/utils/roleUtils.ts
+++ b/src/test/unit/test/utils/roleUtils.ts
@@ -3,7 +3,7 @@ import {
   constructUserRoleAssignments,
   processMfaRole, rolesExist
 } from '../../../../main/utils/roleUtils';
-import { Role } from '../../../../main/interfaces/Role';
+import { V2Role } from '../../../../main/interfaces/V2Role';
 import { User } from '../../../../main/interfaces/User';
 
 describe('roleUtils', () => {
@@ -12,29 +12,26 @@ describe('roleUtils', () => {
     const role2 = 'role2';
     const role3 = 'role3';
 
-    const allRoles: Role[] = [
+    const allRoles: V2Role[] = [
       {
         id: '1',
         name: role1,
         description: role1,
-        assignableRoles: [role2],
-        conflictingRoles: [],
+        assignableRoleNames: [role2],
         assigned: true
       },
       {
         id: '2',
         name: role2,
         description: role2,
-        assignableRoles: [role3],
-        conflictingRoles: [],
+        assignableRoleNames: [role3],
         assigned: true
       },
       {
         id: '3',
         name: role3,
         description: role3,
-        assignableRoles: [],
-        conflictingRoles: [],
+        assignableRoleNames: [],
         assigned: true
       }
     ];
@@ -166,10 +163,10 @@ describe('roleUtils', () => {
     const role4 = 'role4';
     const role5 = 'role5';
 
-    const rolesMap = new Map<string, Role>([
-      [role1, { id: role1, name: role1, description: role1, assignableRoles: [], conflictingRoles: [], assigned: false }],
-      [role2, { id: role2, name: role2, description: role2, assignableRoles: [], conflictingRoles: [], assigned: false }],
-      [role3, { id: role3, name: role3, description: role3, assignableRoles: [], conflictingRoles: [], assigned: false }]
+    const rolesMap = new Map<string, V2Role>([
+      [role1, { id: role1, name: role1, description: role1, assignableRoleNames: [], assigned: false }],
+      [role2, { id: role2, name: role2, description: role2, assignableRoleNames: [], assigned: false }],
+      [role3, { id: role3, name: role3, description: role3, assignableRoleNames: [], assigned: false }]
     ]);
 
     test('Should return true if all role IDs exist in the roles map', async () => {

--- a/src/test/unit/test/utils/serviceUtils.ts
+++ b/src/test/unit/test/utils/serviceUtils.ts
@@ -3,7 +3,7 @@ import {
   getServicesForSelect,
   hasPrivateBetaServices
 } from '../../../../main/utils/serviceUtils';
-import { Role } from '../../../../main/interfaces/Role';
+import { V2Role } from '../../../../main/interfaces/V2Role';
 
 describe('serviceUtils', () => {
   const service1 = 'Service1';
@@ -14,9 +14,9 @@ describe('serviceUtils', () => {
   const role1 = 'other1';
   const role2 = 'other2';
   const nonExistingRole = 'nonExisting';
-  const rolesMap = new Map<string, Role>([
-    [role1, { id: role1, name: role1, description: role1, assignableRoles: [], conflictingRoles: [], assigned: false }],
-    [role2, { id: role2, name: role2, description: role2, assignableRoles: [], conflictingRoles: [], assigned: false }]
+  const rolesMap = new Map<string, V2Role>([
+    [role1, { id: role1, name: role1, description: role1, assignableRoleNames: [], assigned: false }],
+    [role2, { id: role2, name: role2, description: role2, assignableRoleNames: [], assigned: false }]
   ]);
 
   describe('hasPrivateBetaServices', () => {

--- a/src/test/unit/utils/mockApi.ts
+++ b/src/test/unit/utils/mockApi.ts
@@ -13,6 +13,7 @@ export const mockApi: Mocked<IdamAPI> = {
   registerUser: jest.fn(),
   getAllServices: jest.fn(),
   getAllRoles: jest.fn(),
+  getAllV2Roles: jest.fn(),
   getAssignableRoles: jest.fn(),
   grantRolesToUser: jest.fn(),
   removeRoleFromUser: jest.fn(),

--- a/src/test/unit/utils/mockApi.ts
+++ b/src/test/unit/utils/mockApi.ts
@@ -12,7 +12,6 @@ export const mockApi: Mocked<IdamAPI> = {
   removeSsoById: jest.fn(),
   registerUser: jest.fn(),
   getAllServices: jest.fn(),
-  getAllRoles: jest.fn(),
   getAllV2Roles: jest.fn(),
   getAssignableRoles: jest.fn(),
   grantRolesToUser: jest.fn(),


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/SIDM-9354

### Change description ###

Remove clientAxios by switching v2 get user call to use the *other* client credentials token that dashboard has.
Remove systemAxios by switching to v2 get all roles and using client credentials instead of a password grant.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
