### PR TITLE
improve HttpError

### DIFF
--- a/src/main/app/errors/HttpError.ts
+++ b/src/main/app/errors/HttpError.ts
@@ -3,6 +3,11 @@ export class HTTPError extends Error {
 
   constructor(status: number, message?: string) {
     super(message);
+    this.name = 'HTTPError';
     this.status = status;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, HTTPError);
+    }
   }
 }

--- a/src/main/app/invite-service/InviteService.ts
+++ b/src/main/app/invite-service/InviteService.ts
@@ -35,8 +35,10 @@ export class InviteService {
         }
       )
       .catch(err => {
-        logger.error('Failed to send invite' + invitationType + ' invite  for email ' + obfuscate(invite.email));
-        throw new HTTPError(http.HTTP_STATUS_INTERNAL_SERVER_ERROR, err);
+        logger.error(
+          'Failed to send ' + invitationType + ' invite for email ' + obfuscate(invite.email) + ': ' + (err.stack || err)
+        );
+        throw new HTTPError(http.HTTP_STATUS_INTERNAL_SERVER_ERROR, 'Error sending invite to IDAM API');
       });
   };
 

--- a/src/main/modules/error-handler/index.ts
+++ b/src/main/modules/error-handler/index.ts
@@ -38,16 +38,12 @@ function getErrorLogContext(
   error: Error,
   req: AuthedRequest,
   principal: Partial<User> | undefined,
-  status: number,
   errorUUID?: string
 ): Record<string, string | number | undefined> {
   return {
     errorUUID,
     errorName: error.name,
-    status,
     message: error.message,
-    method: req.method,
-    url: req.originalUrl || req.url,
     principalId: principal?.id,
     principalEmail: principal?.email ? obfuscate(principal.email) : undefined,
     stack: error.stack,
@@ -84,16 +80,16 @@ export class ErrorHandler {
       switch(status) {
         case http.HTTP_STATUS_UNAUTHORIZED:
           errorSummary = UNAUTHORIZED;
-          logger.warn('Handled HTTPError', getErrorLogContext(error, req, principal, status));
+          logger.warn('Handled HTTPError', getErrorLogContext(error, req, principal));
           break;
         case http.HTTP_STATUS_FORBIDDEN:
           errorSummary = FORBIDDEN;
-          logger.warn('Handled HTTPError', getErrorLogContext(error, req, principal, status));
+          logger.warn('Handled HTTPError', getErrorLogContext(error, req, principal));
           break;
         default:
           errorSummary = SERVER_ERROR;
           errorUUID = uuid();
-          logger.error('Unhandled HTTPError', getErrorLogContext(error, req, principal, status, errorUUID));
+          logger.error('Unhandled HTTPError', getErrorLogContext(error, req, principal, errorUUID));
       }
 
       res.status(status);

--- a/src/main/modules/error-handler/index.ts
+++ b/src/main/modules/error-handler/index.ts
@@ -6,6 +6,7 @@ import logger from '../logging';
 import { isObjectEmpty } from '../../utils/utils';
 import { AuthedRequest } from 'interfaces/AuthedRequest';
 import { User } from 'interfaces/User';
+const obfuscate = require('obfuscate-mail');
 
 const NOT_FOUND = {
   title: 'Page not found',
@@ -36,7 +37,7 @@ const SERVER_ERROR = {
 function getErrorLogContext(
   error: Error,
   req: AuthedRequest,
-  user: Partial<User> | undefined,
+  principal: Partial<User> | undefined,
   status: number,
   errorUUID?: string
 ): Record<string, string | number | undefined> {
@@ -47,8 +48,8 @@ function getErrorLogContext(
     message: error.message,
     method: req.method,
     url: req.originalUrl || req.url,
-    userId: user?.id,
-    userEmail: user?.email,
+    principalId: principal?.id,
+    principalEmail: principal?.email ? obfuscate(principal.email) : undefined,
     stack: error.stack,
   };
 }
@@ -70,33 +71,33 @@ export class ErrorHandler {
       res.locals.error = app.locals.ENV === 'development' ? error : {};
       let errorSummary: ErrorSummary;
       let errorUUID: string;
-      let user: Partial<User>;
+      let principal: Partial<User>;
       const status = error.status || 500;
     
       if(req.idam_user_dashboard_session) {
-        const sessionUser = req.idam_user_dashboard_session.user;
-        if(sessionUser && !isObjectEmpty(sessionUser)) {
-          user = sessionUser;
+        const sessionPrincipal = req.idam_user_dashboard_session.user;
+        if(sessionPrincipal && !isObjectEmpty(sessionPrincipal)) {
+          principal = sessionPrincipal;
         }
       }
 
       switch(status) {
         case http.HTTP_STATUS_UNAUTHORIZED:
           errorSummary = UNAUTHORIZED;
-          logger.warn('Handled HTTPError', getErrorLogContext(error, req, user, status));
+          logger.warn('Handled HTTPError', getErrorLogContext(error, req, principal, status));
           break;
         case http.HTTP_STATUS_FORBIDDEN:
           errorSummary = FORBIDDEN;
-          logger.warn('Handled HTTPError', getErrorLogContext(error, req, user, status));
+          logger.warn('Handled HTTPError', getErrorLogContext(error, req, principal, status));
           break;
         default:
           errorSummary = SERVER_ERROR;
           errorUUID = uuid();
-          logger.error('Unhandled HTTPError', getErrorLogContext(error, req, user, status, errorUUID));
+          logger.error('Unhandled HTTPError', getErrorLogContext(error, req, principal, status, errorUUID));
       }
 
       res.status(status);
-      res.render('error.njk', {...errorSummary, status, errorUUID, user});
+      res.render('error.njk', {...errorSummary, status, errorUUID, user: principal});
     });
   }
 }

--- a/src/main/modules/error-handler/index.ts
+++ b/src/main/modules/error-handler/index.ts
@@ -33,6 +33,26 @@ const SERVER_ERROR = {
   suggestions: ['Please try again later.']
 };
 
+function getErrorLogContext(
+  error: Error,
+  req: AuthedRequest,
+  user: Partial<User> | undefined,
+  status: number,
+  errorUUID?: string
+): Record<string, string | number | undefined> {
+  return {
+    errorUUID,
+    errorName: error.name,
+    status,
+    message: error.message,
+    method: req.method,
+    url: req.originalUrl || req.url,
+    userId: user?.id,
+    userEmail: user?.email,
+    stack: error.stack,
+  };
+}
+
 export class ErrorHandler {
 
   public enableFor(app: Application): void {
@@ -63,14 +83,16 @@ export class ErrorHandler {
       switch(status) {
         case http.HTTP_STATUS_UNAUTHORIZED:
           errorSummary = UNAUTHORIZED;
+          logger.warn('Handled HTTPError', getErrorLogContext(error, req, user, status));
           break;
         case http.HTTP_STATUS_FORBIDDEN:
           errorSummary = FORBIDDEN;
+          logger.warn('Handled HTTPError', getErrorLogContext(error, req, user, status));
           break;
         default:
           errorSummary = SERVER_ERROR;
           errorUUID = uuid();
-          logger.error(`(logger) errorUUID: ${errorUUID} \n ${error.stack || error}`);
+          logger.error('Unhandled HTTPError', getErrorLogContext(error, req, user, status, errorUUID));
       }
 
       res.status(status);

--- a/src/test/unit/test/app/invite-service/InviteService.ts
+++ b/src/test/unit/test/app/invite-service/InviteService.ts
@@ -3,6 +3,7 @@ import { InviteService } from '../../../../../main/app/invite-service/InviteServ
 import config from 'config';
 import { when } from 'jest-when';
 import { mockAxios } from '../../../utils/mockAxios';
+import { constants as http } from 'http2';
 
 jest.mock('config');
 
@@ -89,7 +90,10 @@ describe('InviteService', () => {
 
       (mockedAxios.post as jest.Mock).mockRejectedValue(true);
 
-      expect(inviteService.inviteUser(invite)).rejects.toThrow();
+      expect(inviteService.inviteUser(invite)).rejects.toMatchObject({
+        status: http.HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        message: 'Error sending invite to IDAM API',
+      });
     });
   });
 });

--- a/src/test/unit/test/modules/error-handler/ErrorHandler.test.ts
+++ b/src/test/unit/test/modules/error-handler/ErrorHandler.test.ts
@@ -1,0 +1,145 @@
+const logger = {
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+const uuidMock = jest.fn(() => 'error-uuid-123');
+
+jest.mock('../../../../../main/modules/logging', () => ({
+  __esModule: true,
+  default: logger,
+}));
+
+jest.mock('uuid', () => ({
+  __esModule: true,
+  v4: () => uuidMock(),
+}));
+
+import { constants as http } from 'http2';
+import { ErrorHandler } from '../../../../../main/modules/error-handler';
+import { HTTPError } from '../../../../../main/app/errors/HttpError';
+
+const makeApp = (env = 'production') => {
+  const handlers: Function[] = [];
+  const app: any = {
+    locals: { ENV: env },
+    use: jest.fn((handler: Function) => {
+      handlers.push(handler);
+      return app;
+    }),
+  };
+
+  return { app, handlers };
+};
+
+const makeRequest = () => ({
+  method: 'GET',
+  url: '/admin/users',
+  originalUrl: '/admin/users?role=caseworker',
+  idam_user_dashboard_session: {
+    user: {
+      id: '12345',
+      email: 'operator@example.com',
+      roles: ['caseworker'],
+    },
+  },
+});
+
+const makeResponse = () => {
+  const res: any = {
+    locals: {},
+    status: jest.fn(),
+    render: jest.fn(),
+  };
+
+  res.status.mockReturnValue(res);
+  res.render.mockReturnValue(res);
+
+  return res;
+};
+
+describe('ErrorHandler', () => {
+  beforeEach(() => {
+    logger.warn.mockReset();
+    logger.error.mockReset();
+    uuidMock.mockClear();
+  });
+
+  test('logs handled HTTPError messages for forbidden responses without exposing them in render data', () => {
+    const { app, handlers } = makeApp();
+    const errorHandler = new ErrorHandler();
+
+    errorHandler.enableFor(app);
+
+    const middleware = handlers[1] as Function;
+    const req = makeRequest();
+    const res = makeResponse();
+    const error = new HTTPError(http.HTTP_STATUS_FORBIDDEN, 'Missing required role assignment');
+
+    middleware(error, req, res, jest.fn());
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Handled HTTPError',
+      expect.objectContaining({
+        errorName: 'HTTPError',
+        status: http.HTTP_STATUS_FORBIDDEN,
+        message: 'Missing required role assignment',
+        method: 'GET',
+        url: '/admin/users?role=caseworker',
+        userId: '12345',
+        userEmail: 'operator@example.com',
+        stack: expect.stringContaining('HTTPError: Missing required role assignment'),
+      })
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(http.HTTP_STATUS_FORBIDDEN);
+    expect(res.render).toHaveBeenCalledWith(
+      'error.njk',
+      expect.objectContaining({
+        status: http.HTTP_STATUS_FORBIDDEN,
+        title: 'Sorry, access to this resource is forbidden',
+      })
+    );
+    expect(res.render.mock.calls[0][1].message).toBeUndefined();
+  });
+
+  test('logs unhandled HTTPError messages with an error UUID and stack trace', () => {
+    const { app, handlers } = makeApp();
+    const errorHandler = new ErrorHandler();
+
+    errorHandler.enableFor(app);
+
+    const middleware = handlers[1] as Function;
+    const req = makeRequest();
+    const res = makeResponse();
+    const error = new HTTPError(http.HTTP_STATUS_INTERNAL_SERVER_ERROR, 'Downstream API timed out');
+
+    middleware(error, req, res, jest.fn());
+
+    expect(uuidMock).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Unhandled HTTPError',
+      expect.objectContaining({
+        errorUUID: 'error-uuid-123',
+        errorName: 'HTTPError',
+        status: http.HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        message: 'Downstream API timed out',
+        method: 'GET',
+        url: '/admin/users?role=caseworker',
+        userId: '12345',
+        userEmail: 'operator@example.com',
+        stack: expect.stringContaining('HTTPError: Downstream API timed out'),
+      })
+    );
+    expect(res.status).toHaveBeenCalledWith(http.HTTP_STATUS_INTERNAL_SERVER_ERROR);
+    expect(res.render).toHaveBeenCalledWith(
+      'error.njk',
+      expect.objectContaining({
+        status: http.HTTP_STATUS_INTERNAL_SERVER_ERROR,
+        errorUUID: 'error-uuid-123',
+        title: 'Sorry, there is a problem with the service',
+      })
+    );
+    expect(res.render.mock.calls[0][1].message).toBeUndefined();
+  });
+});

--- a/src/test/unit/test/modules/error-handler/ErrorHandler.test.ts
+++ b/src/test/unit/test/modules/error-handler/ErrorHandler.test.ts
@@ -86,8 +86,8 @@ describe('ErrorHandler', () => {
         message: 'Missing required role assignment',
         method: 'GET',
         url: '/admin/users?role=caseworker',
-        userId: '12345',
-        userEmail: 'operator@example.com',
+        principalId: '12345',
+        principalEmail: 'ope******r@***.com',
         stack: expect.stringContaining('HTTPError: Missing required role assignment'),
       })
     );
@@ -126,8 +126,8 @@ describe('ErrorHandler', () => {
         message: 'Downstream API timed out',
         method: 'GET',
         url: '/admin/users?role=caseworker',
-        userId: '12345',
-        userEmail: 'operator@example.com',
+        principalId: '12345',
+        principalEmail: 'ope******r@***.com',
         stack: expect.stringContaining('HTTPError: Downstream API timed out'),
       })
     );

--- a/src/test/unit/test/modules/error-handler/ErrorHandler.test.ts
+++ b/src/test/unit/test/modules/error-handler/ErrorHandler.test.ts
@@ -82,10 +82,7 @@ describe('ErrorHandler', () => {
       'Handled HTTPError',
       expect.objectContaining({
         errorName: 'HTTPError',
-        status: http.HTTP_STATUS_FORBIDDEN,
         message: 'Missing required role assignment',
-        method: 'GET',
-        url: '/admin/users?role=caseworker',
         principalId: '12345',
         principalEmail: 'ope******r@***.com',
         stack: expect.stringContaining('HTTPError: Missing required role assignment'),
@@ -122,10 +119,7 @@ describe('ErrorHandler', () => {
       expect.objectContaining({
         errorUUID: 'error-uuid-123',
         errorName: 'HTTPError',
-        status: http.HTTP_STATUS_INTERNAL_SERVER_ERROR,
         message: 'Downstream API timed out',
-        method: 'GET',
-        url: '/admin/users?role=caseworker',
         principalId: '12345',
         principalEmail: 'ope******r@***.com',
         stack: expect.stringContaining('HTTPError: Downstream API timed out'),


### PR DESCRIPTION
### JIRA link ###

Improvement

### Change description ###

- Normalised HTTPError usage so the second parameter is consistently treated as a string message.
- Improved operator-facing error logging in the shared error handler without changing the user-facing error page.
- Added explicit HTTPError metadata to logs, including clearer stack traces and error type naming.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
