### PR TITLE
Pin protobufjs to address audit finding

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "diff": "^8.0.3",
     "lodash": "^4.18.0",
     "axios": "^1.13.5",
+    "protobufjs": "7.5.5",
     "bn.js": "^5.2.3",
     "test-exclude": "^8.0.0",
     "minimatch": "^10.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16127,9 +16127,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.0":
-  version: 7.4.0
-  resolution: "protobufjs@npm:7.4.0"
+"protobufjs@npm:7.5.5":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -16143,7 +16143,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10/408423506610f70858d7593632f4a6aa4f05796c90fd632be9b9252457c795acc71aa6d3b54bb7f48a890141728fee4ca3906723ccea6c202ad71f21b3879b8b
+  checksum: 10/048898023a38d22f5fc9a1bcf0dcce5cfbcd37fb00753bd72283720eee7e2cb6055b23957542e5bcdc136379af66203a2ddb8d8c39d11f73169bacf07885fedd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### JIRA link ###
Support


### Change description ###
Pins protobufjs to 7.5.5 to remove the unsuppressed audit finding reported in CI.
https://github.com/advisories/GHSA-xq3m-2v4x-88gg

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
