### PR TITLE
Support: resolve uuid to 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@types/require-directory": "^2.1.7",
     "@types/serve-favicon": "^2.5.7",
     "@types/session-file-store": "^1.2.5",
-    "@types/uuid": "^9.0.8",
     "autobind-decorator": "^2.4.0",
     "awilix": "^11.0.4",
     "axe-playwright": "^2.0.3",
@@ -96,7 +95,7 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.3",
-    "uuid": "^10.0.0",
+    "uuid": "^14.0.0",
     "winston": "^3.19.0"
   },
   "devDependencies": {
@@ -176,6 +175,7 @@
     "@babel/helpers": "^7.26.10",
     "superagent": ">=10.2.3",
     "on-headers": "^1.1.0",
+    "uuid@npm:^8.3.0": "14.0.0",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
     "jws": "^4.0.1",

--- a/src/test/unit/test/app/reports/ReportsHandler.ts
+++ b/src/test/unit/test/app/reports/ReportsHandler.ts
@@ -1,11 +1,15 @@
 import { ReportsHandler } from '../../../../../main/app/reports/ReportsHandler';
 import { fs } from 'memfs';
-import * as uuid from 'uuid';
 import config from 'config';
 import { when } from 'jest-when';
 
+const mockUuidV4 = jest.fn();
+
 jest.mock('memfs');
-jest.mock('uuid');
+jest.mock('uuid', () => ({
+  __esModule: true,
+  v4: () => mockUuidV4()
+}));
 jest.mock('config');
 const redisClientMock = {
   set: jest.fn((a, b, c, d, callback) => callback(null, true)),
@@ -16,8 +20,6 @@ jest.mock('ioredis', () => ({
 }));
 
 describe('Report handler', () => {
-  jest.spyOn(uuid, 'v4');
-
   const singleRole = [ 'IDAM_SUPER_USER' ];
   const multipleRoles = [ 'IDAM_SUPER_USER', 'IDAM_ADMIN_USER' ];
 
@@ -35,7 +37,7 @@ describe('Report handler', () => {
         const reportUUID = '5';
 
         when(fs.promises.writeFile).mockResolvedValue();
-        when(uuid.v4).mockReturnValue(reportUUID);
+        mockUuidV4.mockReturnValue(reportUUID);
 
         const reportsHandler = new ReportsHandler();
 
@@ -47,7 +49,7 @@ describe('Report handler', () => {
         const reportUUID = '5';
 
         when(fs.promises.writeFile).mockResolvedValue();
-        when(uuid.v4).mockReturnValue(reportUUID);
+        mockUuidV4.mockReturnValue(reportUUID);
 
         const reportsHandler = new ReportsHandler();
 
@@ -58,7 +60,7 @@ describe('Report handler', () => {
       test('Return rejected promise when failing to write file', async () => {
         const reportUUID = '5';
 
-        when(uuid.v4).mockReturnValue(reportUUID);
+        mockUuidV4.mockReturnValue(reportUUID);
         when(fs.promises.writeFile).mockRejectedValue(false);
 
         const reportsHandler = new ReportsHandler();
@@ -106,7 +108,7 @@ describe('Report handler', () => {
       test('Saves report query with single user roles', async () => {
         const reportUUID = '5';
 
-        when(uuid.v4).mockReturnValue(reportUUID);
+        mockUuidV4.mockReturnValue(reportUUID);
 
         const reportsHandler = new ReportsHandler();
 
@@ -117,7 +119,7 @@ describe('Report handler', () => {
       test('Saves report query with multiple user roles', async () => {
         const reportUUID = '5';
 
-        when(uuid.v4).mockReturnValue(reportUUID);
+        mockUuidV4.mockReturnValue(reportUUID);
 
         const reportsHandler = new ReportsHandler();
 
@@ -128,7 +130,7 @@ describe('Report handler', () => {
       test('Return rejected promise when failing to add record to redis', async () => {
         const reportUUID = '5';
 
-        when(uuid.v4).mockReturnValue(reportUUID);
+        mockUuidV4.mockReturnValue(reportUUID);
         when(redisClientMock.set).mockImplementation((a, b, c, d, callback) => callback(true, null));
 
         const reportsHandler = new ReportsHandler();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6263,7 +6263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:9.0.8, @types/uuid@npm:^9.0.8":
+"@types/uuid@npm:9.0.8":
   version: 9.0.8
   resolution: "@types/uuid@npm:9.0.8"
   checksum: 10/b8c60b7ba8250356b5088302583d1704a4e1a13558d143c549c408bf8920535602ffc12394ede77f8a8083511b023704bc66d1345792714002bfa261b17c5275
@@ -11808,7 +11808,6 @@ __metadata:
     "@types/require-directory": "npm:^2.1.7"
     "@types/serve-favicon": "npm:^2.5.7"
     "@types/session-file-store": "npm:^1.2.5"
-    "@types/uuid": "npm:^9.0.8"
     "@types/webpack-dev-middleware": "npm:^5.3.0"
     "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
     "@typescript-eslint/eslint-plugin-tslint": "npm:^7.0.2"
@@ -11870,7 +11869,7 @@ __metadata:
     tsconfig-paths: "npm:^4.2.0"
     tslint: "npm:6.1.3"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^10.0.0"
+    uuid: "npm:^14.0.0"
     webpack: "npm:5.106.2"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-middleware: "npm:^7.4.2"
@@ -18825,6 +18824,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:14.0.0, uuid@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10/8ee9b98f9650e25555515f7a28d3c3ae9364e72f7bb19b9e08b681bc135338beba5509b2830f6ae1cfaba4d45401da0d16d4d109b977097bc3d6ba0c5583341b
+  languageName: node
+  linkType: hard
+
 "uuid@npm:9.0.0":
   version: 9.0.0
   resolution: "uuid@npm:9.0.0"
@@ -18849,15 +18857,6 @@ __metadata:
   bin:
     uuid: ./bin/uuid
   checksum: 10/4f2b86432b04cc7c73a0dd1bcf11f1fc18349d65d2e4e32dd0fc658909329a1e0cc9244aa93f34c0cccfdd5ae1af60a149251a5f420ec3ac4223a3dab198fb2e
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.0":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10/9a5f7aa1d6f56dd1e8d5f2478f855f25c645e64e26e347a98e98d95781d5ed20062d6cca2eecb58ba7c84bc3910be95c0451ef4161906abaab44f9cb68ffbdd1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### JIRA link ###

Support

### Change description ###

- upgrade the app's direct `uuid` dependency to `^14.0.0`
- remove the separate `@types/uuid` dependency
- add a Yarn resolution so `@azure/msal-node` resolves its `uuid:^8.3.0` slot to `14.0.0`
- update the `ReportsHandler` unit test to use an explicit `uuid` factory mock compatible with `uuid@14`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
