### PR TITLE
Test repeated authorization request

### DIFF
--- a/src/test/playwright/fixtures/admin.fixture.ts
+++ b/src/test/playwright/fixtures/admin.fixture.ts
@@ -16,7 +16,7 @@ export const test = base.extend<AdminFixtures>({
     }
     const adminEmail = getAdminEmailForProject(testInfo.project.name);
     await setupDao.setupAdmin(adminEmail);
-    await page.goto('/');
+    await page.goto('/login');
     await expect(page.locator('h1')).toHaveText('What do you want to do?');
     await use();
   }, { auto: true }],

--- a/src/test/playwright/specs/sign_in.spec.ts
+++ b/src/test/playwright/specs/sign_in.spec.ts
@@ -1,10 +1,6 @@
-import { Page, Request } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { test, expect } from '../fixtures/base.fixture';
 import { loginAs } from '../helpers/ui-auth';
-
-function isAuthorizationRequest(request: Request): boolean {
-  return new URL(request.url()).pathname === '/o/authorize';
-}
 
 async function loginWithCredentials(page: Page, email: string, password: string): Promise<void> {
   await page.goto('/');
@@ -47,32 +43,6 @@ test.describe('sign_in', () => {
     const cookies = await context.cookies();
     const cookieNames = cookies.map((cookie) => cookie.name);
     expect(cookieNames, 'session cookie is set after admin login').toContain('idam_user_dashboard_session');
-  });
-
-  test('logged-in user can authorize again', async ({ page, setupDao }) => {
-    const testUser = await setupDao.createUser({
-      roleNames: ['idam-user-dashboard--access'],
-    });
-
-    const initialAuthorizationRequestPromise = page.waitForRequest(isAuthorizationRequest);
-    await loginAs(page, testUser.email, testUser.password);
-    const initialAuthorizationRequest = await initialAuthorizationRequestPromise;
-    await expect(page.locator('h1')).toHaveText('What do you want to do?');
-
-    const repeatedAuthorizationRequestPromise = page.waitForRequest(isAuthorizationRequest);
-    await page.goto('/login');
-    const repeatedAuthorizationRequest = await repeatedAuthorizationRequestPromise;
-
-    const initialAuthorizationUrl = new URL(initialAuthorizationRequest.url());
-    const repeatedAuthorizationUrl = new URL(repeatedAuthorizationRequest.url());
-    expect(repeatedAuthorizationUrl.pathname).toBe('/o/authorize');
-    expect(repeatedAuthorizationUrl.searchParams.get('client_id'))
-      .toBe(initialAuthorizationUrl.searchParams.get('client_id'));
-    expect(repeatedAuthorizationUrl.searchParams.get('redirect_uri'))
-      .toBe(initialAuthorizationUrl.searchParams.get('redirect_uri'));
-    expect(repeatedAuthorizationUrl.searchParams.get('state'))
-      .not.toBe(initialAuthorizationUrl.searchParams.get('state'));
-    await expect(page.locator('h1')).toHaveText('What do you want to do?');
   });
 
   test('login as user without access', async ({ page, setupDao, context }) => {

--- a/src/test/playwright/specs/sign_in.spec.ts
+++ b/src/test/playwright/specs/sign_in.spec.ts
@@ -1,6 +1,10 @@
-import { Page } from '@playwright/test';
+import { Page, Request } from '@playwright/test';
 import { test, expect } from '../fixtures/base.fixture';
 import { loginAs } from '../helpers/ui-auth';
+
+function isAuthorizationRequest(request: Request): boolean {
+  return new URL(request.url()).pathname === '/o/authorize';
+}
 
 async function loginWithCredentials(page: Page, email: string, password: string): Promise<void> {
   await page.goto('/');
@@ -43,6 +47,32 @@ test.describe('sign_in', () => {
     const cookies = await context.cookies();
     const cookieNames = cookies.map((cookie) => cookie.name);
     expect(cookieNames, 'session cookie is set after admin login').toContain('idam_user_dashboard_session');
+  });
+
+  test('logged-in user can authorize again', async ({ page, setupDao }) => {
+    const testUser = await setupDao.createUser({
+      roleNames: ['idam-user-dashboard--access'],
+    });
+
+    const initialAuthorizationRequestPromise = page.waitForRequest(isAuthorizationRequest);
+    await loginAs(page, testUser.email, testUser.password);
+    const initialAuthorizationRequest = await initialAuthorizationRequestPromise;
+    await expect(page.locator('h1')).toHaveText('What do you want to do?');
+
+    const repeatedAuthorizationRequestPromise = page.waitForRequest(isAuthorizationRequest);
+    await page.goto('/login');
+    const repeatedAuthorizationRequest = await repeatedAuthorizationRequestPromise;
+
+    const initialAuthorizationUrl = new URL(initialAuthorizationRequest.url());
+    const repeatedAuthorizationUrl = new URL(repeatedAuthorizationRequest.url());
+    expect(repeatedAuthorizationUrl.pathname).toBe('/o/authorize');
+    expect(repeatedAuthorizationUrl.searchParams.get('client_id'))
+      .toBe(initialAuthorizationUrl.searchParams.get('client_id'));
+    expect(repeatedAuthorizationUrl.searchParams.get('redirect_uri'))
+      .toBe(initialAuthorizationUrl.searchParams.get('redirect_uri'));
+    expect(repeatedAuthorizationUrl.searchParams.get('state'))
+      .not.toBe(initialAuthorizationUrl.searchParams.get('state'));
+    await expect(page.locator('h1')).toHaveText('What do you want to do?');
   });
 
   test('login as user without access', async ({ page, setupDao, context }) => {


### PR DESCRIPTION
### JIRA link ###

N/A - test-only investigation.

### Change description ###

This test-only PR changes the Playwright admin fixture to visit `/login` instead of `/` before each authenticated test.

Visiting `/login` redirects through IDAM's `/o/authorize` endpoint while reusing the saved admin authentication state. This exercises repeated authorization requests and verifies that the flow returns successfully to the dashboard before each test continues.

No production application code is changed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
